### PR TITLE
fix: unwrap kippymap_action payload before mapping

### DIFF
--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -301,10 +301,12 @@ class KippyApi:
 
         data = await self._post_with_refresh(KIPPYMAP_ACTION_PATH, payload, headers)
 
-        tech = data.get("localization_tecnology")
+        payload = data.get("data", {})
+
+        tech = payload.get("localization_tecnology")
         if tech is not None:
-            data["localization_technology"] = LOCALIZATION_TECHNOLOGY_MAP.get(
+            payload["localization_technology"] = LOCALIZATION_TECHNOLOGY_MAP.get(
                 str(tech), str(tech)
             )
 
-        return data
+        return payload


### PR DESCRIPTION
## Summary
- extract inner payload from kippymap_action response
- map `localization_tecnology` within payload data

## Testing
- `python -m compileall custom_components/kippy/api.py custom_components/kippy`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b49bf816a88326bf51fcf07d0d4a9b