### PR TITLE
Add configurable refresh for Kippy live tracking

### DIFF
--- a/custom_components/kippy/__init__.py
+++ b/custom_components/kippy/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.helpers import aiohttp_client
 
 from .api import KippyApi
 from .const import DOMAIN, PLATFORMS
-from .coordinator import KippyDataUpdateCoordinator
+from .coordinator import KippyDataUpdateCoordinator, KippyMapDataUpdateCoordinator
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Kippy from a config entry."""
@@ -25,10 +25,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await api.login(email, password)
         coordinator = KippyDataUpdateCoordinator(hass, api)
         await coordinator.async_config_entry_first_refresh()
+
+        map_coordinators = {}
+        for pet in coordinator.data.get("pets", []):
+            kippy_id = pet.get("kippyID") or pet.get("kippy_id") or pet.get("petID")
+            map_coordinator = KippyMapDataUpdateCoordinator(hass, api, int(kippy_id))
+            await map_coordinator.async_config_entry_first_refresh()
+            map_coordinators[pet["petID"]] = map_coordinator
     except Exception as err:  # noqa: BLE001
         raise ConfigEntryNotReady from err
 
-    hass.data[DOMAIN][entry.entry_id] = {"api": api, "coordinator": coordinator}
+    hass.data[DOMAIN][entry.entry_id] = {
+        "api": api,
+        "coordinator": coordinator,
+        "map_coordinators": map_coordinators,
+    }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -13,7 +13,7 @@ from aiohttp import ClientError, ClientResponseError, ClientSession
 DEFAULT_HOST = "https://prod.kippyapi.eu"
 LOGIN_PATH = "/v2/login.php"
 GET_PETS_PATH = "/v2/GetPetKippyList.php"
-KIPPYMAP_ACTION_PATH = "/v2/kippymap_action.php"
+KIPPYMAP_ACTION_PATH = "/t/v2/kippymap_action.php"
 
 LOCALIZATION_TECHNOLOGY_MAP: dict[str, str] = {
     "2": "GPS",

--- a/custom_components/kippy/device_tracker.py
+++ b/custom_components/kippy/device_tracker.py
@@ -10,36 +10,38 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, PET_KIND_TO_TYPE
-from .coordinator import KippyDataUpdateCoordinator
+from .coordinator import KippyMapDataUpdateCoordinator
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
     """Set up Kippy device trackers."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    base_coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    map_coordinators = hass.data[DOMAIN][entry.entry_id]["map_coordinators"]
 
     entities = [
-        KippyPetTracker(coordinator, pet)
-        for pet in coordinator.data.get("pets", [])
+        KippyPetTracker(map_coordinators[pet["petID"]], pet)
+        for pet in base_coordinator.data.get("pets", [])
     ]
     async_add_entities(entities)
 
 
-class KippyPetTracker(CoordinatorEntity[KippyDataUpdateCoordinator], TrackerEntity):
+class KippyPetTracker(CoordinatorEntity[KippyMapDataUpdateCoordinator], TrackerEntity):
     """Representation of a Kippy tracked pet."""
 
-    def __init__(self, coordinator: KippyDataUpdateCoordinator, pet: dict[str, Any]) -> None:
+    def __init__(self, coordinator: KippyMapDataUpdateCoordinator, pet: dict[str, Any]) -> None:
         """Initialize the tracker entity."""
         super().__init__(coordinator)
         self._pet_id = pet["petID"]
         pet_name = pet.get("petName")
         self._attr_name = f"Kippy {pet_name}" if pet_name else "Kippy"
         self._attr_unique_id = pet["petID"]
-        self._pet_data = pet
+        self._pet_data = dict(pet)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the attributes provided by the API."""
         attrs = dict(self._pet_data)
+        attrs.update(self.coordinator.data or {})
         expired_days = attrs.get("expired_days")
         if isinstance(expired_days, (int, str)):
             try:
@@ -65,12 +67,14 @@ class KippyPetTracker(CoordinatorEntity[KippyDataUpdateCoordinator], TrackerEnti
     @property
     def latitude(self) -> float | None:
         """Return latitude if available."""
-        return None
+        lat = self.coordinator.data.get("gps_latitude") if self.coordinator.data else None
+        return float(lat) if lat is not None else None
 
     @property
     def longitude(self) -> float | None:
         """Return longitude if available."""
-        return None
+        lon = self.coordinator.data.get("gps_longitude") if self.coordinator.data else None
+        return float(lon) if lon is not None else None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -83,12 +87,5 @@ class KippyPetTracker(CoordinatorEntity[KippyDataUpdateCoordinator], TrackerEnti
             sw_version=self._pet_data.get("kippyFirmware"),
         )
 
-    def _handle_coordinator_update(self) -> None:
-        """Update internal data from the coordinator."""
-        for pet in self.coordinator.data.get("pets", []):
-            if pet.get("petID") == self._pet_id:
-                self._pet_data = pet
-                pet_name = pet.get("petName")
-                self._attr_name = f"Kippy {pet_name}" if pet_name else "Kippy"
-                break
+    def _handle_coordinator_update(self) -> None:  # pragma: no cover - simple passthrough
         super()._handle_coordinator_update()

--- a/custom_components/kippy/number.py
+++ b/custom_components/kippy/number.py
@@ -1,6 +1,8 @@
 """Number entities for Kippy pets."""
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.components.number import NumberEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -8,17 +10,21 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .coordinator import KippyDataUpdateCoordinator
+from .coordinator import KippyDataUpdateCoordinator, KippyMapDataUpdateCoordinator
 
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up Kippy number entities."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    base_coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    map_coordinators = hass.data[DOMAIN][entry.entry_id]["map_coordinators"]
     entities: list[NumberEntity] = []
-    for pet in coordinator.data.get("pets", []):
-        entities.append(KippyUpdateFrequencyNumber(coordinator, pet))
+    for pet in base_coordinator.data.get("pets", []):
+        entities.append(KippyUpdateFrequencyNumber(base_coordinator, pet))
+        map_coord = map_coordinators[pet["petID"]]
+        entities.append(KippyIdleRefreshNumber(map_coord, pet))
+        entities.append(KippyLiveRefreshNumber(map_coord, pet))
     async_add_entities(entities)
 
 
@@ -54,6 +60,86 @@ class KippyUpdateFrequencyNumber(CoordinatorEntity[KippyDataUpdateCoordinator], 
                 self._pet_data = pet
                 break
         super()._handle_coordinator_update()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        pet_name = self._pet_data.get("petName")
+        name = f"Kippy {pet_name}" if pet_name else "Kippy"
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._pet_id)},
+            name=name,
+            manufacturer="Kippy",
+            model=self._pet_data.get("kippyType"),
+            sw_version=self._pet_data.get("kippyFirmware"),
+        )
+
+
+class KippyIdleRefreshNumber(
+    CoordinatorEntity[KippyMapDataUpdateCoordinator], NumberEntity
+):
+    """Number entity for idle refresh time."""
+
+    _attr_native_min_value = 1
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = "s"
+
+    def __init__(self, coordinator: KippyMapDataUpdateCoordinator, pet: dict[str, Any]) -> None:
+        super().__init__(coordinator)
+        self._pet_id = pet["petID"]
+        self._pet_data = pet
+        pet_name = pet.get("petName")
+        self._attr_name = (
+            f"{pet_name} Idle refresh time" if pet_name else "Idle refresh time"
+        )
+        self._attr_unique_id = f"{self._pet_id}_idle_refresh_time"
+
+    @property
+    def native_value(self) -> float | None:
+        return float(self.coordinator.idle_refresh)
+
+    async def async_set_native_value(self, value: float) -> None:
+        self.coordinator.set_idle_refresh(int(value))
+        self.async_write_ha_state()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        pet_name = self._pet_data.get("petName")
+        name = f"Kippy {pet_name}" if pet_name else "Kippy"
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._pet_id)},
+            name=name,
+            manufacturer="Kippy",
+            model=self._pet_data.get("kippyType"),
+            sw_version=self._pet_data.get("kippyFirmware"),
+        )
+
+
+class KippyLiveRefreshNumber(
+    CoordinatorEntity[KippyMapDataUpdateCoordinator], NumberEntity
+):
+    """Number entity for live refresh time."""
+
+    _attr_native_min_value = 1
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = "s"
+
+    def __init__(self, coordinator: KippyMapDataUpdateCoordinator, pet: dict[str, Any]) -> None:
+        super().__init__(coordinator)
+        self._pet_id = pet["petID"]
+        self._pet_data = pet
+        pet_name = pet.get("petName")
+        self._attr_name = (
+            f"{pet_name} Live refresh time" if pet_name else "Live refresh time"
+        )
+        self._attr_unique_id = f"{self._pet_id}_live_refresh_time"
+
+    @property
+    def native_value(self) -> float | None:
+        return float(self.coordinator.live_refresh)
+
+    async def async_set_native_value(self, value: float) -> None:
+        self.coordinator.set_live_refresh(int(value))
+        self.async_write_ha_state()
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/kippy/strings.json
+++ b/custom_components/kippy/strings.json
@@ -22,6 +22,13 @@
           "on": "Yes",
           "off": "No"
         }
+      },
+      "live_tracking": {
+        "name": "Live tracking",
+        "state": {
+          "on": "Live",
+          "off": "Idle"
+        }
       }
     }
   }

--- a/custom_components/kippy/translations/en.json
+++ b/custom_components/kippy/translations/en.json
@@ -24,6 +24,13 @@
           "on": "Yes",
           "off": "No"
         }
+      },
+      "live_tracking": {
+        "name": "Live tracking",
+        "state": {
+          "on": "Live",
+          "off": "Idle"
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- periodically call `/t/v2/kippymap_action.php` to refresh position data
- add live-tracking binary sensor and configurable idle/live refresh numbers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_68b4a0a340f0832696843b1af807c795