### PR TITLE
Fix live tracking status comparison and update rescheduling

### DIFF
--- a/custom_components/kippy/__init__.py
+++ b/custom_components/kippy/__init__.py
@@ -47,6 +47,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload Kippy config entry."""
-    await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    hass.data[DOMAIN].pop(entry.entry_id)
-    return True
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        data = hass.data[DOMAIN].pop(entry.entry_id)
+        await data["coordinator"].async_config_entry_last_unload()
+        for coordinator in data["map_coordinators"].values():
+            await coordinator.async_config_entry_last_unload()
+    return unload_ok

--- a/custom_components/kippy/binary_sensor.py
+++ b/custom_components/kippy/binary_sensor.py
@@ -86,7 +86,7 @@ class KippyLiveTrackingBinarySensor(
 
     @property
     def is_on(self) -> bool:
-        return bool(self.coordinator.data.get("operating_status") == 1)
+        return bool(int(self.coordinator.data.get("operating_status") or 0) == 1)
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/kippy/coordinator.py
+++ b/custom_components/kippy/coordinator.py
@@ -60,21 +60,29 @@ class KippyMapDataUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self):
         """Fetch location data and adjust the refresh interval."""
         data = await self.api.kippymap_action(self.kippy_id)
-        operating_status = data.get("operating_status")
+        operating_status = int(data.get("operating_status") or 0)
         if operating_status == 1:
-            self.update_interval = timedelta(seconds=self.live_refresh)
+            await self.async_set_update_interval(
+                timedelta(seconds=self.live_refresh)
+            )
         else:
-            self.update_interval = timedelta(seconds=self.idle_refresh)
+            await self.async_set_update_interval(
+                timedelta(seconds=self.idle_refresh)
+            )
         return data
 
-    def set_idle_refresh(self, value: int) -> None:
+    async def async_set_idle_refresh(self, value: int) -> None:
         """Update idle refresh value and interval when idle."""
         self.idle_refresh = value
-        if self.data and self.data.get("operating_status") != 1:
-            self.update_interval = timedelta(seconds=self.idle_refresh)
+        if self.data and int(self.data.get("operating_status") or 0) != 1:
+            await self.async_set_update_interval(
+                timedelta(seconds=self.idle_refresh)
+            )
 
-    def set_live_refresh(self, value: int) -> None:
+    async def async_set_live_refresh(self, value: int) -> None:
         """Update live refresh value and interval when live."""
         self.live_refresh = value
-        if self.data and self.data.get("operating_status") == 1:
-            self.update_interval = timedelta(seconds=self.live_refresh)
+        if self.data and int(self.data.get("operating_status") or 0) == 1:
+            await self.async_set_update_interval(
+                timedelta(seconds=self.live_refresh)
+            )

--- a/custom_components/kippy/number.py
+++ b/custom_components/kippy/number.py
@@ -98,7 +98,7 @@ class KippyIdleRefreshNumber(
         return float(self.coordinator.idle_refresh)
 
     async def async_set_native_value(self, value: float) -> None:
-        self.coordinator.set_idle_refresh(int(value))
+        await self.coordinator.async_set_idle_refresh(int(value))
         self.async_write_ha_state()
 
     @property
@@ -138,7 +138,7 @@ class KippyLiveRefreshNumber(
         return float(self.coordinator.live_refresh)
 
     async def async_set_native_value(self, value: float) -> None:
-        self.coordinator.set_live_refresh(int(value))
+        await self.coordinator.async_set_live_refresh(int(value))
         self.async_write_ha_state()
 
     @property


### PR DESCRIPTION
## Summary
- normalize `operating_status` before comparison and reschedule update intervals
- await refresh interval changes and stop per-pet coordinators on unload

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest >/tmp/pytest.log ; tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b4a5205ec88326ab221688add37973