### PR TITLE
Fix kippymap action URL

### DIFF
--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -13,7 +13,7 @@ from aiohttp import ClientError, ClientResponseError, ClientSession
 DEFAULT_HOST = "https://prod.kippyapi.eu"
 LOGIN_PATH = "/v2/login.php"
 GET_PETS_PATH = "/v2/GetPetKippyList.php"
-KIPPYMAP_ACTION_PATH = "/t/v2/kippymap_action.php"
+KIPPYMAP_ACTION_PATH = "/v2/kippymap_action.php"
 
 LOCALIZATION_TECHNOLOGY_MAP: dict[str, str] = {
     "2": "GPS",


### PR DESCRIPTION
## Summary
- fix kippymap action URL

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4ab3ebf3c83268fed0a3be9e14457