### PR TITLE
Fix dynamic update interval for Kippy Map coordinator

### DIFF
--- a/custom_components/kippy/coordinator.py
+++ b/custom_components/kippy/coordinator.py
@@ -66,9 +66,9 @@ class KippyMapDataUpdateCoordinator(DataUpdateCoordinator):
         except (TypeError, ValueError):
             operating_status = None
         if operating_status == 1:
-            self.async_set_update_interval(timedelta(seconds=self.live_refresh))
+            self.update_interval = timedelta(seconds=self.live_refresh)
         else:
-            self.async_set_update_interval(timedelta(seconds=self.idle_refresh))
+            self.update_interval = timedelta(seconds=self.idle_refresh)
         return data
 
     async def async_set_idle_refresh(self, value: int) -> None:
@@ -81,9 +81,7 @@ class KippyMapDataUpdateCoordinator(DataUpdateCoordinator):
             except (TypeError, ValueError):
                 operating_status = None
             if operating_status != 1:
-                self.async_set_update_interval(
-                    timedelta(seconds=self.idle_refresh)
-                )
+                self.update_interval = timedelta(seconds=self.idle_refresh)
 
     async def async_set_live_refresh(self, value: int) -> None:
         """Update live refresh value and interval when live."""
@@ -95,6 +93,4 @@ class KippyMapDataUpdateCoordinator(DataUpdateCoordinator):
             except (TypeError, ValueError):
                 operating_status = None
             if operating_status == 1:
-                self.async_set_update_interval(
-                    timedelta(seconds=self.live_refresh)
-                )
+                self.update_interval = timedelta(seconds=self.live_refresh)


### PR DESCRIPTION
## Summary
- replace missing async_set_update_interval calls with update_interval property

## Testing
- `pytest`
- `python -m compileall -f custom_components/kippy`


------
https://chatgpt.com/codex/tasks/task_e_68b4b042be5c8326984a8f5fd0cfa576