### PR TITLE
Handle 401 responses with valid data from Kippy API

### DIFF
--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -200,7 +200,7 @@ class KippyApi:
                     except json.JSONDecodeError:
                         data = None
 
-                    if resp.status == 401 and data:
+                    if resp.status == 401 and isinstance(data, dict):
                         return_code = data.get("return")
                         if str(return_code).lower() in ("true", "1"):
                             return data


### PR DESCRIPTION
## Summary
- Tolerate 401 responses that still return valid data from `kippymap_action`
- Accept boolean `return` values as success in API helper
- Guard against non-dict JSON when inspecting 401 responses

## Testing
- `python -m ruff check custom_components/kippy/api.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4b1accc648326acb0a8f5fb348935