### PR TITLE
Rename live tracking to operating status and add toggle

### DIFF
--- a/custom_components/kippy/binary_sensor.py
+++ b/custom_components/kippy/binary_sensor.py
@@ -22,7 +22,9 @@ async def async_setup_entry(
     entities: list[BinarySensorEntity] = []
     for pet in coordinator.data.get("pets", []):
         entities.append(KippyFirmwareUpgradeAvailableBinarySensor(coordinator, pet))
-        entities.append(KippyLiveTrackingBinarySensor(map_coordinators[pet["petID"]], pet))
+        entities.append(
+            KippyOperatingStatusBinarySensor(map_coordinators[pet["petID"]], pet)
+        )
     async_add_entities(entities)
 
 
@@ -66,10 +68,10 @@ class KippyFirmwareUpgradeAvailableBinarySensor(
         )
 
 
-class KippyLiveTrackingBinarySensor(
+class KippyOperatingStatusBinarySensor(
     CoordinatorEntity[KippyMapDataUpdateCoordinator], BinarySensorEntity
 ):
-    """Binary sensor indicating live tracking status."""
+    """Binary sensor indicating operating status."""
 
     def __init__(
         self, coordinator: KippyMapDataUpdateCoordinator, pet: dict[str, Any]
@@ -78,11 +80,11 @@ class KippyLiveTrackingBinarySensor(
         self._pet_id = pet["petID"]
         pet_name = pet.get("petName")
         self._attr_name = (
-            f"{pet_name} Live tracking" if pet_name else "Live tracking"
+            f"{pet_name} Operating status" if pet_name else "Operating status"
         )
         self._attr_unique_id = f"{self._pet_id}_live_tracking"
         self._pet_name = pet_name
-        self._attr_translation_key = "live_tracking"
+        self._attr_translation_key = "operating_status"
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/kippy/strings.json
+++ b/custom_components/kippy/strings.json
@@ -23,11 +23,20 @@
           "off": "No"
         }
       },
-      "live_tracking": {
-        "name": "Live tracking",
+      "operating_status": {
+        "name": "Operating status",
         "state": {
           "on": "Live",
           "off": "Idle"
+        }
+      }
+    },
+    "switch": {
+      "toggle_live_tracking": {
+        "name": "Toggle live tracking",
+        "state": {
+          "on": "On",
+          "off": "Off"
         }
       }
     }

--- a/custom_components/kippy/translations/en.json
+++ b/custom_components/kippy/translations/en.json
@@ -25,11 +25,20 @@
           "off": "No"
         }
       },
-      "live_tracking": {
-        "name": "Live tracking",
+      "operating_status": {
+        "name": "Operating status",
         "state": {
           "on": "Live",
           "off": "Idle"
+        }
+      }
+    },
+    "switch": {
+      "toggle_live_tracking": {
+        "name": "Toggle live tracking",
+        "state": {
+          "on": "On",
+          "off": "Off"
         }
       }
     }


### PR DESCRIPTION
## Summary
- rename live tracking binary sensor to operating status
- add toggle live tracking switch that triggers kippymap_action with `app_action=1`

## Testing
- `python -m compileall -q custom_components/kippy`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4bef474b48326a26a3cc0454f2c23