### PR TITLE
Add debug response logging and diagnostic press button

### DIFF
--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -121,6 +121,8 @@ class KippyApi:
                 ssl=self._ssl_context,
             ) as resp:
                 resp_text = await resp.text()
+                if _LOGGER.isEnabledFor(logging.DEBUG):
+                    _LOGGER.debug("Login response: %s", resp_text)
                 try:
                     resp.raise_for_status()
                 except ClientResponseError as err:
@@ -192,6 +194,8 @@ class KippyApi:
                     ssl=self._ssl_context,
                 ) as resp:
                     resp_text = await resp.text()
+                    if _LOGGER.isEnabledFor(logging.DEBUG):
+                        _LOGGER.debug("%s response: %s", path, resp_text)
                     # Try to decode the response even on HTTP errors as some
                     # endpoints (e.g. ``kippymap_action``) incorrectly return a
                     # 401 status code while still providing valid data.

--- a/custom_components/kippy/button.py
+++ b/custom_components/kippy/button.py
@@ -1,0 +1,61 @@
+"""Button entities for Kippy pets."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import KippyDataUpdateCoordinator, KippyMapDataUpdateCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+) -> None:
+    """Set up Kippy button entities."""
+    coordinator: KippyDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][
+        "coordinator"
+    ]
+    map_coordinators: dict[int, KippyMapDataUpdateCoordinator] = hass.data[DOMAIN][
+        entry.entry_id
+    ]["map_coordinators"]
+    entities: list[ButtonEntity] = []
+    for pet in coordinator.data.get("pets", []):
+        entities.append(KippyPressButton(map_coordinators[pet["petID"]], pet))
+    async_add_entities(entities)
+
+
+class KippyPressButton(
+    CoordinatorEntity[KippyMapDataUpdateCoordinator], ButtonEntity
+):
+    """Button to trigger an immediate kippymap action."""
+
+    def __init__(
+        self, coordinator: KippyMapDataUpdateCoordinator, pet: dict[str, Any]
+    ) -> None:
+        super().__init__(coordinator)
+        self._pet_id = pet["petID"]
+        pet_name = pet.get("petName")
+        self._attr_name = f"{pet_name} Press" if pet_name else "Press"
+        self._attr_unique_id = f"{self._pet_id}_press"
+        self._pet_name = pet_name
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_translation_key = "press"
+
+    async def async_press(self) -> None:
+        data = await self.coordinator.api.kippymap_action(self._pet_id)
+        self.coordinator.async_set_updated_data(data)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        name = f"Kippy {self._pet_name}" if self._pet_name else "Kippy"
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._pet_id)},
+            name=name,
+            manufacturer="Kippy",
+        )

--- a/custom_components/kippy/const.py
+++ b/custom_components/kippy/const.py
@@ -9,6 +9,7 @@ PLATFORMS: list[str] = [
     "number",
     "switch",
     "binary_sensor",
+    "button",
 ]
 
 # Mapping of operating status codes returned by the API.

--- a/custom_components/kippy/strings.json
+++ b/custom_components/kippy/strings.json
@@ -39,6 +39,11 @@
           "off": "Off"
         }
       }
+    },
+    "button": {
+      "press": {
+        "name": "Press"
+      }
     }
   }
 }

--- a/custom_components/kippy/translations/en.json
+++ b/custom_components/kippy/translations/en.json
@@ -41,6 +41,11 @@
           "off": "Off"
         }
       }
+    },
+    "button": {
+      "press": {
+        "name": "Press"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Log raw API response bodies when debug logging is enabled
- Add diagnostic press button to trigger immediate kippymap action
- Add translations for new button entity

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4c10b643c8326af5281b9a2a6a7e2