### PR TITLE
Log request bodies when debug enabled

### DIFF
--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -114,6 +114,8 @@ class KippyApi:
         }
 
         try:
+            if _LOGGER.isEnabledFor(logging.DEBUG):
+                _LOGGER.debug("Login request: %s", payload)
             async with self._session.post(
                 self._url(LOGIN_PATH),
                 data=json.dumps(payload),
@@ -187,6 +189,8 @@ class KippyApi:
 
         for attempt in range(2):
             try:
+                if _LOGGER.isEnabledFor(logging.DEBUG):
+                    _LOGGER.debug("%s request: %s", path, payload)
                 async with self._session.post(
                     self._url(path),
                     data=json.dumps(payload),


### PR DESCRIPTION
## Summary
- Log login request data when debug logging is enabled
- Log payloads for other API calls when debug logging is enabled

## Testing
- `python -m py_compile custom_components/kippy/api.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4c3de41d08326b53fc0d3fcd2decd