### PR TITLE
Use device kippy id for kippymap actions

### DIFF
--- a/custom_components/kippy/button.py
+++ b/custom_components/kippy/button.py
@@ -48,7 +48,7 @@ class KippyPressButton(
         self._attr_translation_key = "press"
 
     async def async_press(self) -> None:
-        data = await self.coordinator.api.kippymap_action(self._pet_id)
+        data = await self.coordinator.api.kippymap_action(self.coordinator.kippy_id)
         self.coordinator.async_set_updated_data(data)
 
     @property

--- a/custom_components/kippy/switch.py
+++ b/custom_components/kippy/switch.py
@@ -102,14 +102,14 @@ class KippyLiveTrackingSwitch(
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         data = await self.coordinator.api.kippymap_action(
-            self._pet_id, app_action=1
+            self.coordinator.kippy_id, app_action=1
         )
         self.coordinator.async_set_updated_data(data)
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         data = await self.coordinator.api.kippymap_action(
-            self._pet_id, app_action=1
+            self.coordinator.kippy_id, app_action=1
         )
         self.coordinator.async_set_updated_data(data)
         self.async_write_ha_state()


### PR DESCRIPTION
## Summary
- Use the coordinator's device kippy ID for kippymap actions
- Ensure live tracking switch uses device kippy ID for on/off

## Testing
- `python -m pytest`
- Custom script to invoke button and switch actions and verify full API responses


------
https://chatgpt.com/codex/tasks/task_e_68b4c8acf1cc8326ace8490323e330b3