### PR TITLE
Include Kippy identifiers in device info

### DIFF
--- a/custom_components/kippy/binary_sensor.py
+++ b/custom_components/kippy/binary_sensor.py
@@ -7,6 +7,8 @@ from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
+
+from .helpers import build_device_info
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, OPERATING_STATUS_LIVE
@@ -59,13 +61,7 @@ class KippyFirmwareUpgradeAvailableBinarySensor(
     def device_info(self) -> DeviceInfo:
         pet_name = self._pet_data.get("petName")
         name = f"Kippy {pet_name}" if pet_name else "Kippy"
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._pet_id)},
-            name=name,
-            manufacturer="Kippy",
-            model=self._pet_data.get("kippyType"),
-            sw_version=self._pet_data.get("kippyFirmware"),
-        )
+        return build_device_info(self._pet_id, self._pet_data, name)
 
 
 class KippyOperatingStatusBinarySensor(
@@ -84,6 +80,7 @@ class KippyOperatingStatusBinarySensor(
         )
         self._attr_unique_id = f"{self._pet_id}_live_tracking"
         self._pet_name = pet_name
+        self._pet_data = pet
         self._attr_translation_key = "operating_status"
 
     @property
@@ -95,9 +92,5 @@ class KippyOperatingStatusBinarySensor(
     @property
     def device_info(self) -> DeviceInfo:
         name = f"Kippy {self._pet_name}" if self._pet_name else "Kippy"
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._pet_id)},
-            name=name,
-            manufacturer="Kippy",
-        )
+        return build_device_info(self._pet_id, self._pet_data, name)
 

--- a/custom_components/kippy/button.py
+++ b/custom_components/kippy/button.py
@@ -7,6 +7,8 @@ from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
+
+from .helpers import build_device_info
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -44,6 +46,7 @@ class KippyPressButton(
         self._attr_name = f"{pet_name} Press" if pet_name else "Press"
         self._attr_unique_id = f"{self._pet_id}_press"
         self._pet_name = pet_name
+        self._pet_data = pet
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_translation_key = "press"
 
@@ -54,8 +57,4 @@ class KippyPressButton(
     @property
     def device_info(self) -> DeviceInfo:
         name = f"Kippy {self._pet_name}" if self._pet_name else "Kippy"
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._pet_id)},
-            name=name,
-            manufacturer="Kippy",
-        )
+        return build_device_info(self._pet_id, self._pet_data, name)

--- a/custom_components/kippy/config_flow.py
+++ b/custom_components/kippy/config_flow.py
@@ -6,7 +6,6 @@ import voluptuous as vol
 from aiohttp import ClientError, ClientResponseError
 from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
-from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
 
 from .api import KippyApi

--- a/custom_components/kippy/device_tracker.py
+++ b/custom_components/kippy/device_tracker.py
@@ -7,6 +7,8 @@ from homeassistant.components.device_tracker import TrackerEntity, SourceType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
+
+from .helpers import build_device_info
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, PET_KIND_TO_TYPE
@@ -79,13 +81,7 @@ class KippyPetTracker(CoordinatorEntity[KippyMapDataUpdateCoordinator], TrackerE
     @property
     def device_info(self) -> DeviceInfo:
         """Return device information for this pet."""
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._pet_id)},
-            name=self._attr_name,
-            manufacturer="Kippy",
-            model=self._pet_data.get("kippyType"),
-            sw_version=self._pet_data.get("kippyFirmware"),
-        )
+        return build_device_info(self._pet_id, self._pet_data, self._attr_name)
 
     def _handle_coordinator_update(self) -> None:  # pragma: no cover - simple passthrough
         super()._handle_coordinator_update()

--- a/custom_components/kippy/helpers.py
+++ b/custom_components/kippy/helpers.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from .const import DOMAIN
+
+
+def build_device_info(pet_id: int | str, pet: dict[str, Any], name: str) -> DeviceInfo:
+    """Create a DeviceInfo object for a Kippy pet."""
+    identifiers: set[tuple[str, str]] = {(DOMAIN, str(pet_id))}
+
+    kippy_id = pet.get("kippyID") or pet.get("kippy_id")
+    if kippy_id:
+        identifiers.add((DOMAIN, str(kippy_id)))
+
+    kippy_imei = pet.get("kippyIMEI")
+    if kippy_imei:
+        identifiers.add((DOMAIN, str(kippy_imei)))
+
+    return DeviceInfo(
+        identifiers=identifiers,
+        name=name,
+        manufacturer="Kippy",
+        model=pet.get("kippyType"),
+        sw_version=pet.get("kippyFirmware"),
+        serial_number=pet.get("kippySerial"),
+    )

--- a/custom_components/kippy/number.py
+++ b/custom_components/kippy/number.py
@@ -7,6 +7,8 @@ from homeassistant.components.number import NumberEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
+
+from .helpers import build_device_info
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
@@ -68,13 +70,7 @@ class KippyUpdateFrequencyNumber(CoordinatorEntity[KippyDataUpdateCoordinator], 
     def device_info(self) -> DeviceInfo:
         pet_name = self._pet_data.get("petName")
         name = f"Kippy {pet_name}" if pet_name else "Kippy"
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._pet_id)},
-            name=name,
-            manufacturer="Kippy",
-            model=self._pet_data.get("kippyType"),
-            sw_version=self._pet_data.get("kippyFirmware"),
-        )
+        return build_device_info(self._pet_id, self._pet_data, name)
 
 
 class KippyIdleUpdateFrequencyNumber(
@@ -110,13 +106,7 @@ class KippyIdleUpdateFrequencyNumber(
     def device_info(self) -> DeviceInfo:
         pet_name = self._pet_data.get("petName")
         name = f"Kippy {pet_name}" if pet_name else "Kippy"
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._pet_id)},
-            name=name,
-            manufacturer="Kippy",
-            model=self._pet_data.get("kippyType"),
-            sw_version=self._pet_data.get("kippyFirmware"),
-        )
+        return build_device_info(self._pet_id, self._pet_data, name)
 
 
 class KippyLiveUpdateFrequencyNumber(
@@ -152,11 +142,5 @@ class KippyLiveUpdateFrequencyNumber(
     def device_info(self) -> DeviceInfo:
         pet_name = self._pet_data.get("petName")
         name = f"Kippy {pet_name}" if pet_name else "Kippy"
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._pet_id)},
-            name=name,
-            manufacturer="Kippy",
-            model=self._pet_data.get("kippyType"),
-            sw_version=self._pet_data.get("kippyFirmware"),
-        )
+        return build_device_info(self._pet_id, self._pet_data, name)
 

--- a/custom_components/kippy/sensor.py
+++ b/custom_components/kippy/sensor.py
@@ -7,6 +7,8 @@ from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
+
+from .helpers import build_device_info
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, PET_KIND_TO_TYPE
@@ -44,13 +46,7 @@ class _KippyBaseEntity(CoordinatorEntity[KippyDataUpdateCoordinator]):
     def device_info(self) -> DeviceInfo:
         pet_name = self._pet_data.get("petName")
         name = f"Kippy {pet_name}" if pet_name else "Kippy"
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._pet_id)},
-            name=name,
-            manufacturer="Kippy",
-            model=self._pet_data.get("kippyType"),
-            sw_version=self._pet_data.get("kippyFirmware"),
-        )
+        return build_device_info(self._pet_id, self._pet_data, name)
 
 
 class KippyExpiredDaysSensor(_KippyBaseEntity, SensorEntity):

--- a/custom_components/kippy/switch.py
+++ b/custom_components/kippy/switch.py
@@ -7,6 +7,8 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
+
+from .helpers import build_device_info
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, OPERATING_STATUS_LIVE
@@ -67,13 +69,7 @@ class KippyEnergySavingSwitch(
     def device_info(self) -> DeviceInfo:
         pet_name = self._pet_data.get("petName")
         name = f"Kippy {pet_name}" if pet_name else "Kippy"
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._pet_id)},
-            name=name,
-            manufacturer="Kippy",
-            model=self._pet_data.get("kippyType"),
-            sw_version=self._pet_data.get("kippyFirmware"),
-        )
+        return build_device_info(self._pet_id, self._pet_data, name)
 
 
 class KippyLiveTrackingSwitch(
@@ -92,6 +88,7 @@ class KippyLiveTrackingSwitch(
         )
         self._attr_unique_id = f"{self._pet_id}_toggle_live_tracking"
         self._pet_name = pet_name
+        self._pet_data = pet
         self._attr_translation_key = "toggle_live_tracking"
 
     @property
@@ -117,9 +114,5 @@ class KippyLiveTrackingSwitch(
     @property
     def device_info(self) -> DeviceInfo:
         name = f"Kippy {self._pet_name}" if self._pet_name else "Kippy"
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._pet_id)},
-            name=name,
-            manufacturer="Kippy",
-        )
+        return build_device_info(self._pet_id, self._pet_data, name)
 


### PR DESCRIPTION
## Summary
- include serial number, Kippy ID and IMEI in device information
- remove unused import in configuration flow

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4caa90d088326912c998ed6e99b76