### PR TITLE
Expose Kippy ID and IMEI via device connections

### DIFF
--- a/custom_components/kippy/helpers.py
+++ b/custom_components/kippy/helpers.py
@@ -8,19 +8,23 @@ from .const import DOMAIN
 
 
 def build_device_info(pet_id: int | str, pet: dict[str, Any], name: str) -> DeviceInfo:
-    """Create a DeviceInfo object for a Kippy pet."""
+    """Create a DeviceInfo object for a Kippy pet with IDs and IMEI."""
     identifiers: set[tuple[str, str]] = {(DOMAIN, str(pet_id))}
+    connections: set[tuple[str, str]] = set()
 
     kippy_id = pet.get("kippyID") or pet.get("kippy_id")
     if kippy_id:
         identifiers.add((DOMAIN, str(kippy_id)))
+        connections.add(("kippy_id", str(kippy_id)))
 
     kippy_imei = pet.get("kippyIMEI")
     if kippy_imei:
         identifiers.add((DOMAIN, str(kippy_imei)))
+        connections.add(("imei", str(kippy_imei)))
 
     return DeviceInfo(
         identifiers=identifiers,
+        connections=connections or None,
         name=name,
         manufacturer="Kippy",
         model=pet.get("kippyType"),


### PR DESCRIPTION
## Summary
- register each Kippy pet's ID and IMEI as device connections alongside identifiers
- document the helper to clarify ID and IMEI handling

## Testing
- `python -m py_compile custom_components/kippy/helpers.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4ccdf964c8326b4cc717190e31b2d