### PR TITLE
Add GPS data parsing for kippymap action

### DIFF
--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -335,6 +335,20 @@ class KippyApi:
 
         payload = data.get("data", {})
 
+        # Extract primary GPS location details
+        lat = payload.pop("lat", None)
+        if lat is not None:
+            payload["gps_latitude"] = lat
+        lng = payload.pop("lng", None)
+        if lng is not None:
+            payload["gps_longitude"] = lng
+        radius = payload.pop("radius", None)
+        if radius is not None:
+            payload["gps_accuracy"] = radius
+        altitude = payload.pop("altitude", None)
+        if altitude is not None:
+            payload["gps_altitude"] = altitude
+
         tech = payload.get("localization_tecnology")
         if tech is not None:
             payload["localization_technology"] = LOCALIZATION_TECHNOLOGY_MAP.get(

--- a/custom_components/kippy/device_tracker.py
+++ b/custom_components/kippy/device_tracker.py
@@ -79,6 +79,18 @@ class KippyPetTracker(CoordinatorEntity[KippyMapDataUpdateCoordinator], TrackerE
         return float(lon) if lon is not None else None
 
     @property
+    def location_accuracy(self) -> float | None:
+        """Return accuracy radius if available."""
+        acc = self.coordinator.data.get("gps_accuracy") if self.coordinator.data else None
+        return float(acc) if acc is not None else None
+
+    @property
+    def altitude(self) -> float | None:
+        """Return altitude if available."""
+        alt = self.coordinator.data.get("gps_altitude") if self.coordinator.data else None
+        return float(alt) if alt is not None else None
+
+    @property
     def device_info(self) -> DeviceInfo:
         """Return device information for this pet."""
         return build_device_info(self._pet_id, self._pet_data, self._attr_name)


### PR DESCRIPTION
## Summary
- extract latitude, longitude, accuracy radius and altitude from `kippymap_action` responses
- expose location accuracy and altitude in device tracker entities

## Testing
- `python -m py_compile custom_components/kippy/api.py custom_components/kippy/device_tracker.py`


------
https://chatgpt.com/codex/tasks/task_e_68b60301b0408326b9451634c6b92312