### PR TITLE
Fix Kippy device tracker missing GPS and battery

### DIFF
--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -333,7 +333,10 @@ class KippyApi:
 
         data = await self._post_with_refresh(KIPPYMAP_ACTION_PATH, payload, headers)
 
-        payload = data.get("data", {})
+        payload = data.get("data")
+        if not isinstance(payload, dict):
+            payload = dict(data)
+        payload.pop("return", None)
 
         # Extract primary GPS location details
         lat = payload.pop("lat", None)

--- a/custom_components/kippy/device_tracker.py
+++ b/custom_components/kippy/device_tracker.py
@@ -109,6 +109,17 @@ class KippyPetTracker(CoordinatorEntity[KippyMapDataUpdateCoordinator], TrackerE
         return float(alt) if alt is not None else None
 
     @property
+    def battery_level(self) -> int | None:
+        """Return battery level if available."""
+        val = self.coordinator.data.get("battery") if self.coordinator.data else None
+        if val is None:
+            val = self._pet_data.get("batteryLevel") or self._pet_data.get("battery")
+        try:
+            return int(val)
+        except (TypeError, ValueError):
+            return None
+
+    @property
     def device_info(self) -> DeviceInfo:
         """Return device information for this pet."""
         return build_device_info(self._pet_id, self._pet_data, self._attr_name)


### PR DESCRIPTION
## Summary
- handle `kippymap_action` responses that omit the `data` wrapper and strip metadata
- expose numeric battery level on Kippy device tracker entities

## Testing
- `pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b609eb4b588326b1573bd4612622a9