### PR TITLE
Use pet profile images for Kippy device trackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A Home Assistant HACS integration for Kippy pet trackers.
 
 Device trackers created by this integration are prefixed with `Kippy` and your pet's name (for example, `Kippy Tilly`).
+If the Kippy service provides a profile picture for your pet, it will be shown on the device tracker.
 
 ## Installation
 

--- a/custom_components/kippy/device_tracker.py
+++ b/custom_components/kippy/device_tracker.py
@@ -38,6 +38,7 @@ class KippyPetTracker(CoordinatorEntity[KippyMapDataUpdateCoordinator], TrackerE
         self._attr_name = f"Kippy {pet_name}" if pet_name else "Kippy"
         self._attr_unique_id = pet["petID"]
         self._pet_data = dict(pet)
+        self._attr_entity_picture = pet.get("imageCloudURL")
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -61,6 +62,11 @@ class KippyPetTracker(CoordinatorEntity[KippyMapDataUpdateCoordinator], TrackerE
         gps_alt = attrs.pop("gps_altitude", None)
         if gps_alt is not None:
             attrs["altitude"] = gps_alt
+
+        picture = attrs.pop("imageCloudURL", None)
+        if picture:
+            attrs["picture"] = picture
+            self._attr_entity_picture = picture
 
         expired_days = attrs.get("expired_days")
         if isinstance(expired_days, (int, str)):


### PR DESCRIPTION
## Summary
- expose each pet's image from `imageCloudURL` as the tracker picture
- document that pet profile pictures are shown on device trackers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b60e238c048326bb91444f9500c991