### PR TITLE
Add activity categories coordinator and manual refresh button

### DIFF
--- a/custom_components/kippy/strings.json
+++ b/custom_components/kippy/strings.json
@@ -51,6 +51,9 @@
     "button": {
       "press": {
         "name": "Press"
+      },
+      "refresh_activities": {
+        "name": "Refresh activities"
       }
     }
   }

--- a/custom_components/kippy/translations/en.json
+++ b/custom_components/kippy/translations/en.json
@@ -53,6 +53,9 @@
     "button": {
       "press": {
         "name": "Press"
+      },
+      "refresh_activities": {
+        "name": "Refresh activities"
       }
     }
   }


### PR DESCRIPTION
## Summary
- fetch activity category data for each pet on a 6‑hour schedule
- expose cached activity, average and health data for sensors
- add diagnostic button to manually refresh activity categories

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b75d0bc228832687fc7c29163bb24c