### PR TITLE
Handle Result 113 responses from Kippy API

### DIFF
--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -214,6 +214,13 @@ class KippyApi:
 
                     if resp.status == 401 and isinstance(data, dict):
                         return_code = data.get("return")
+                        if return_code is None:
+                            return_code = data.get("Result")
+                            if str(return_code) == "113":
+                                _LOGGER.debug(
+                                    "%s returned Result=113, treating as empty", path
+                                )
+                                return data
                         if str(return_code).lower() in ("true", "1"):
                             return data
                     try:


### PR DESCRIPTION
## Summary
- Handle Kippy API 401 responses with `Result=113` by treating them as empty results
- Ensure request/response logging occurs when debug logging is enabled

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b75f87a578832699859658d075cece