### PR TITLE
Fix timezone offset for activity category requests

### DIFF
--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -6,7 +6,7 @@ import hashlib
 import json
 import logging
 import ssl
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
 
 from aiohttp import ClientError, ClientResponseError, ClientSession
@@ -392,14 +392,18 @@ class KippyApi:
         if not self._auth:
             raise RuntimeError("No authentication data available")
 
-        tz_offset = datetime.now().astimezone().utcoffset() or timedelta()
-        tz_hours = tz_offset.total_seconds() / 3600
-
         start = datetime.strptime(from_date, "%Y-%m-%d")
         end = datetime.strptime(to_date, "%Y-%m-%d")
 
-        from_ts = int((start - tz_offset).replace(tzinfo=timezone.utc).timestamp())
-        to_ts = int((end - tz_offset).replace(tzinfo=timezone.utc).timestamp())
+        local_tz = datetime.now().astimezone().tzinfo
+        start_local = start.replace(tzinfo=local_tz)
+        end_local = end.replace(tzinfo=local_tz)
+
+        tz_offset = start_local.utcoffset() or timedelta()
+        tz_hours = tz_offset.total_seconds() / 3600
+
+        from_ts = int(start_local.timestamp())
+        to_ts = int(end_local.timestamp())
 
         weeks_list: list[dict[str, str]] = []
         current = start


### PR DESCRIPTION
## Summary
- derive timezone offset from request dates when computing activity timestamps

## Testing
- `ruff check custom_components/kippy/api.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b766b049ac832699362a71fa3e49e3