### PR TITLE
Handle 401 Kippy responses with usable data

### DIFF
--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -216,11 +216,16 @@ class KippyApi:
                         return_code = data.get("return")
                         if return_code is None:
                             return_code = data.get("Result")
-                            if str(return_code) == "113":
-                                _LOGGER.debug(
-                                    "%s returned Result=113, treating as empty", path
-                                )
-                                return data
+                        if return_code is None:
+                            _LOGGER.debug(
+                                "%s returned HTTP 401 with data, assuming success", path
+                            )
+                            return data
+                        if str(return_code) == "113":
+                            _LOGGER.debug(
+                                "%s returned Result=113, treating as empty", path
+                            )
+                            return data
                         if str(return_code) in ("0", "1") or str(return_code).lower() == "true":
                             return data
                     try:


### PR DESCRIPTION
## Summary
- Treat HTTP 401 responses that still contain data as successful
- Avoid setup failures when API incorrectly returns 401 with valid payload

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b76851c7b48326a565b0f0e324d19f