### PR TITLE
Handle Result field in Kippy API responses

### DIFF
--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -253,7 +253,11 @@ class KippyApi:
                     if data is None:
                         data = json.loads(resp_text)
                     return_code = data.get("return")
-                    if return_code not in (0, "0", True, "true"):
+                    if return_code is None:
+                        return_code = data.get("Result")
+                    if return_code is None:
+                        return data
+                    if str(return_code).lower() not in {"0", "1", "true"}:
                         _LOGGER.debug(
                             "%s failed: return=%s request=%s response=%s",
                             path,


### PR DESCRIPTION
## Summary
- Treat `Result` as a valid success indicator in Kippy API responses
- Return data when no explicit return code is provided

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b76ac905dc8326afb998839bcc5321