### PR TITLE
Handle Result field in Kippy API responses

### DIFF
--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -226,7 +226,7 @@ class KippyApi:
                                 "%s returned Result=113, treating as empty", path
                             )
                             return data
-                        if str(return_code) in ("0", "1") or str(return_code).lower() == "true":
+                        if str(return_code) == "0" or str(return_code).lower() == "true":
                             return data
                     try:
                         resp.raise_for_status()
@@ -257,7 +257,7 @@ class KippyApi:
                         return_code = data.get("Result")
                     if return_code is None:
                         return data
-                    if str(return_code).lower() not in {"0", "1", "true"}:
+                    if str(return_code).lower() not in {"0", "true"}:
                         _LOGGER.debug(
                             "%s failed: return=%s request=%s response=%s",
                             path,


### PR DESCRIPTION
## Summary
- Treat `Result` as a valid success indicator in Kippy API responses
- Return data when no explicit return code is provided
- Do not treat return code `1` as success

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b76ce2aff88326bd17e01f97f4a131