### PR TITLE
Handle cat activity categories in sensors

### DIFF
--- a/custom_components/kippy/sensor.py
+++ b/custom_components/kippy/sensor.py
@@ -195,7 +195,7 @@ class _KippyActivitySensor(
         activities = self.coordinator.get_activities(self._pet_id)
         if not activities:
             return None
-        today = datetime.utcnow()
+        today = datetime.now()
         value: Any = None
 
         # Cat trackers return data grouped by activity rather than by day.


### PR DESCRIPTION
## Summary
- handle activity data grouped by category for cat trackers
- use local timezone when matching cat activity entries

## Testing
- `pre-commit run --files custom_components/kippy/sensor.py` *(fails: .pre-commit-config.yaml is not a file)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7f03e3ccc832686dabbae2d40aa01