### PR TITLE
Recursively redact nested fields in API logs

### DIFF
--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,0 +1,33 @@
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+KIPPY_DIR = Path(__file__).resolve().parents[1] / "custom_components" / "kippy"
+custom_components = types.ModuleType("custom_components")
+sys.modules.setdefault("custom_components", custom_components)
+spec = importlib.util.spec_from_file_location(
+    "custom_components.kippy.api", KIPPY_DIR / "api.py"
+)
+api = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(api)
+_redact = api._redact
+_redact_json = api._redact_json
+
+
+def test_redact_json_handles_nested_fields():
+    payload = {
+        "data": [{"petID": "123", "info": {"auth_token": "abc"}}],
+        "auth_token": "def",
+    }
+    redacted = _redact_json(json.dumps(payload))
+    assert '"petID": "***"' in redacted
+    assert '"auth_token": "***"' in redacted
+
+
+def test_redact_handles_nested_fields():
+    payload = {"outer": {"app_code": "xyz", "list": [{"auth_token": "abc"}]}}
+    redacted = _redact(payload)
+    assert redacted["outer"]["app_code"] == "***"
+    assert redacted["outer"]["list"][0]["auth_token"] == "***"


### PR DESCRIPTION
## Summary
- walk nested dicts/lists when redacting API logs
- test redaction against nested JSON structures

## Testing
- `pre-commit run --files custom_components/kippy/api.py tests/test_redaction.py`
- `pytest -q`
- `pip install homeassistant` *(failed: AttributeError: cython_sources)*

------
https://chatgpt.com/codex/tasks/task_e_68b803c7bd688326a4e07581249ee737