### PR TITLE
Add test requirements file

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+pytest==8.0.2
+pytest-asyncio==0.23.5
+pytest-cov==4.1.0
+pytest-homeassistant-custom-component==0.13.109


### PR DESCRIPTION
## Summary
- add requirements-test.txt with explicit testing dependencies
- pin versions to match pytest-homeassistant-custom-component constraints

## Testing
- `pre-commit run --files requirements-test.txt`
- `pip install -r requirements-test.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b812baeb68832682ce2ade3ed0a068