### PR TITLE
Pin Home Assistant 2025.8.3 and streamline sensor tests

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,1 @@
+-c https://raw.githubusercontent.com/home-assistant/core/2025.8.3/homeassistant/package_constraints.txt

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-pytest==8.0.2
-pytest-asyncio==0.23.5
-pytest-cov==4.1.0
-pytest-homeassistant-custom-component==0.13.109
+pytest==8.4.1
+pytest-asyncio==1.1.0
+pytest-cov==6.2.1
+aiohttp==3.12.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+-c constraints.txt
+homeassistant==2025.8.3
+-r requirements-test.txt

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,21 +1,13 @@
-import logging
 from unittest.mock import MagicMock
-from pathlib import Path
-import sys
 
 import pytest
-try:
-    from homeassistant.core import HomeAssistant
-except ModuleNotFoundError:
-    pytest.skip("HomeAssistant not installed", allow_module_level=True)
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from custom_components.kippy.const import PET_KIND_TO_TYPE
 from custom_components.kippy.sensor import KippyExpiredDaysSensor, KippyPetTypeSensor
 
 
 @pytest.mark.asyncio
-async def test_expired_days_sensor_returns_expired(hass: HomeAssistant) -> None:
+async def test_expired_days_sensor_returns_expired() -> None:
     """Ensure non-negative days report as 'Expired'."""
     pet = {"petID": "1", "expired_days": 0}
     coordinator = MagicMock()
@@ -30,7 +22,7 @@ async def test_expired_days_sensor_returns_expired(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.asyncio
-async def test_expired_days_sensor_returns_positive_days(hass: HomeAssistant) -> None:
+async def test_expired_days_sensor_returns_positive_days() -> None:
     """Negative days are returned as positive remaining days."""
     pet = {"petID": "1", "expired_days": -3}
     coordinator = MagicMock()
@@ -42,7 +34,7 @@ async def test_expired_days_sensor_returns_positive_days(hass: HomeAssistant) ->
 
 
 @pytest.mark.asyncio
-async def test_pet_type_sensor_maps_kind_to_type(hass: HomeAssistant) -> None:
+async def test_pet_type_sensor_maps_kind_to_type() -> None:
     """Pet type sensor should map kind code to type label."""
     pet = {"petID": "1", "petKind": "4"}
     coordinator = MagicMock()


### PR DESCRIPTION
## Summary
- reference Home Assistant 2025.8.3 constraint set
- add development requirements with pinned Home Assistant
- drop unused Home Assistant fixture from sensor tests

## Testing
- `SKIP=prettier python -m pre_commit run --files constraints.txt requirements.txt requirements-test.txt tests/test_sensor.py`
- `python -m pip install -r requirements.txt --progress-bar off`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8159b6e048326aeb811dc1411fa6c