### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,72 @@
+{
+  "name": "Kippy Home Assistant HACS Dev",
+  "context": "..",
+  "dockerFile": "../Dockerfile.dev",
+  "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && ./script/setup",
+  "postStartCommand": "./script/bootstrap",
+  "containerEnv": {
+    "PYTHONASYNCIODEBUG": "1"
+  },
+  "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  // Port 5683 udp is used by Shelly integration
+  "appPort": ["8123:8123", "5683:5683/udp"],
+  "runArgs": [
+    "-e",
+    "GIT_EDITOR=code --wait",
+    "--security-opt",
+    "label=disable"
+  ],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "charliermarsh.ruff",
+        "ms-python.pylint",
+        "ms-python.vscode-pylance",
+        "visualstudioexptteam.vscodeintellicode",
+        "redhat.vscode-yaml",
+        "esbenp.prettier-vscode",
+        "GitHub.vscode-pull-request-github",
+        "GitHub.copilot"
+      ],
+      // Please keep this file in sync with settings in home-assistant/.vscode/settings.default.json
+      "settings": {
+        "python.experiments.optOutFrom": ["pythonTestAdapter"],
+        "python.defaultInterpreterPath": "/home/vscode/.local/ha-venv/bin/python",
+        "python.pythonPath": "/home/vscode/.local/ha-venv/bin/python",
+        "python.terminal.activateEnvInCurrentTerminal": true,
+        "python.testing.pytestArgs": ["--no-cov"],
+        "pylint.importStrategy": "fromEnvironment",
+        "editor.formatOnPaste": false,
+        "editor.formatOnSave": true,
+        "editor.formatOnType": true,
+        "files.trimTrailingWhitespace": true,
+        "terminal.integrated.profiles.linux": {
+          "zsh": {
+            "path": "/usr/bin/zsh"
+          }
+        },
+        "terminal.integrated.defaultProfile.linux": "zsh",
+        "yaml.customTags": [
+          "!input scalar",
+          "!secret scalar",
+          "!include_dir_named scalar",
+          "!include_dir_list scalar",
+          "!include_dir_merge_list scalar",
+          "!include_dir_merge_named scalar"
+        ],
+        "[python]": {
+          "editor.defaultFormatter": "charliermarsh.ruff"
+        },
+        "json.schemas": [
+          {
+            "fileMatch": ["homeassistant/components/*/manifest.json"],
+            "url": "${containerWorkspaceFolder}/script/json_schemas/manifest_schema.json"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Install dependencies for kippy-homeassistant-hacs
+set -e
+
+cd "$(realpath "$(dirname "$0")/..")"
+
+echo "Installing project dependencies..."
+uv pip install -r requirements.txt --upgrade

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Set up the development environment for kippy-homeassistant-hacs
+set -e
+
+cd "$(dirname "$0")/.."
+
+# Create virtual environment if not already activated
+if [ ! -n "$VIRTUAL_ENV" ]; then
+  if command -v uv >/dev/null 2>&1; then
+    uv venv .venv
+  else
+    python3 -m venv .venv
+  fi
+  source .venv/bin/activate
+fi
+
+# Ensure uv is available
+if ! command -v uv >/dev/null 2>&1; then
+  python3 -m pip install uv
+fi
+
+# Install project dependencies
+script/bootstrap
+
+# Install pre-commit hooks
+pre-commit install


### PR DESCRIPTION
## Summary
- copy Home Assistant devcontainer configuration and rename for this project
- add setup and bootstrap scripts and wire into devcontainer

## Testing
- `./script/setup` *(fails: Python 3.11 does not satisfy homeassistant==2025.8.3)*
- `pip install -r requirements.txt` *(fails: No matching distribution found for homeassistant==2025.8.3)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiohttp'; 'custom_components' is not a package)*
- `pre-commit run --files script/setup script/bootstrap .devcontainer/devcontainer.json`


------
https://chatgpt.com/codex/tasks/task_e_68b82983ad188326bbb805607e0b9c0e