### PR TITLE
Ensure pre-commit installed during setup

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -19,6 +19,11 @@ if ! command -v uv >/dev/null 2>&1; then
   python3 -m pip install uv
 fi
 
+# Ensure pre-commit is available
+if ! command -v pre-commit >/dev/null 2>&1; then
+  uv pip install pre-commit
+fi
+
 # Install project dependencies
 script/bootstrap
 


### PR DESCRIPTION
## Summary
- Ensure `pre-commit` is installed before running hooks in setup script

## Testing
- `pre-commit run --files script/setup`
- `pytest` *(fails: No module named 'homeassistant')*
- `./script/setup` *(fails: homeassistant requires Python >=3.13.2)*

------
https://chatgpt.com/codex/tasks/task_e_68b842f28c54832688b0007e8ed1544d