### PR TITLE
Pin Home Assistant 2024.3.3

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,1 +1,1 @@
--c https://raw.githubusercontent.com/home-assistant/core/2025.8.3/homeassistant/package_constraints.txt
+-c https://raw.githubusercontent.com/home-assistant/core/2024.3.3/homeassistant/package_constraints.txt

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 pytest==8.4.1
 pytest-asyncio==1.1.0
 pytest-cov==6.2.1
-aiohttp==3.12.15
+aiohttp==3.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 -c constraints.txt
-homeassistant==2025.8.3
+homeassistant==2024.3.3
 -r requirements-test.txt


### PR DESCRIPTION
## Summary
- pin Home Assistant dependency to 2024.3.3
- align aiohttp test dependency with Home Assistant constraints

## Testing
- `pre-commit run --files requirements-test.txt requirements.txt constraints.txt` (fails: certificate verify failed)
- `pip install -r requirements.txt` (fails: conflicting dependencies)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8770905ec83268cbbf73b6d4b67c6