### PR TITLE
Ensure pre-commit is installed during setup

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,4 @@ pytest==8.4.1
 pytest-asyncio==1.1.0
 pytest-cov==6.2.1
 aiohttp==3.9.3
+pre-commit==4.3.0


### PR DESCRIPTION
## Summary
- Include `pre-commit` in test requirements so it's installed during setup

## Testing
- `pre-commit run --files requirements-test.txt` *(fails: ssl.SSLCertVerificationError)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8797bc8d88326abb80ca976ca8e39