### PR TITLE
Add python-dotenv to test requirements

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@ pytest-asyncio==1.1.0
 pytest-cov==6.2.1
 aiohttp==3.9.3
 pre-commit==4.3.0
+python-dotenv==1.1.1


### PR DESCRIPTION
## Summary
- include python-dotenv (provides load_dotenv) in test requirements

## Testing
- `pre-commit run --files requirements-test.txt`
- `python -m pip install -r requirements-test.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8867f17148326bb3aaf7f85326682