### PR TITLE
Add Node.js feature to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
     "PYTHONASYNCIODEBUG": "1"
   },
   "features": {
+    "ghcr.io/devcontainers/features/node:1": {},
     "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {},
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },


### PR DESCRIPTION
## Summary
- install Node.js and npm via devcontainer feature so claude-code CLI can install

## Testing
- `pre-commit run --files .devcontainer/devcontainer.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b89081a74483268139f8d310fbcb12