### PR TITLE
Pin josepy dependency to avoid ACME ComparableX509 error

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,1 +1,2 @@
 -c https://raw.githubusercontent.com/home-assistant/core/2024.3.3/homeassistant/package_constraints.txt
+josepy<2.0.0


### PR DESCRIPTION
## Summary
- pin josepy<2.0.0 to restore compatibility with ACME

## Testing
- `pre-commit run --files constraints.txt`
- `python -m pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b896a97e1c8326aed3f76f455eca07