### PR TITLE
chore: ensure devcontainer uses venv

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "Kippy Home Assistant HACS Dev",
   "image": "mcr.microsoft.com/devcontainers/python:3.11",
-  "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && ./script/setup",
+  "postCreateCommand": "./script/setup",
   "postStartCommand": "./script/bootstrap",
   "containerEnv": {
     "PYTHONASYNCIODEBUG": "1"
@@ -36,6 +36,7 @@
         "python.experiments.optOutFrom": ["pythonTestAdapter"],
         "python.defaultInterpreterPath": "/home/vscode/.local/ha-venv/bin/python",
         "python.pythonPath": "/home/vscode/.local/ha-venv/bin/python",
+        "python.linting.pylintPath": "/home/vscode/.local/ha-venv/bin/pylint",
         "python.terminal.activateEnvInCurrentTerminal": true,
         "python.testing.pytestArgs": ["--no-cov"],
         "pylint.importStrategy": "fromEnvironment",

--- a/script/setup
+++ b/script/setup
@@ -9,6 +9,9 @@ PIP="$VENV_DIR/bin/pip"
 
 cd "$REPO_ROOT"
 
+# Mark the repository as safe for Git inside the container
+git config --global --add safe.directory "$REPO_ROOT"
+
 # Create the venv VS Code/devcontainer is configured to use
 if [ ! -x "$PY" ]; then
   echo "Creating virtualenv at $VENV_DIR ..."


### PR DESCRIPTION
## Summary
- run setup when dev container is created
- run bootstrap when dev container starts
- configure VS Code to use Pylint from project virtualenv
- centralize git-safe-directory config in setup script

## Testing
- `pre-commit run --files .devcontainer/devcontainer.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8996b82908326ae999bc454ac7da1