### PR TITLE
chore: ensure devcontainer uses venv

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "Kippy Home Assistant HACS Dev",
   "image": "mcr.microsoft.com/devcontainers/python:3.11",
-  "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && ./script/setup",
+  "postCreateCommand": "./script/setup",
   "postStartCommand": "./script/bootstrap",
   "containerEnv": {
     "PYTHONASYNCIODEBUG": "1"
@@ -31,11 +31,12 @@
         "GitHub.vscode-pull-request-github",
         "GitHub.copilot"
       ],
-      // Please keep this file in sync with settings in home-assistant/.vscode/settings.default.json
+      // Please keep this file in sync with settings in .vscode/settings.default.json
       "settings": {
         "python.experiments.optOutFrom": ["pythonTestAdapter"],
         "python.defaultInterpreterPath": "/home/vscode/.local/ha-venv/bin/python",
         "python.pythonPath": "/home/vscode/.local/ha-venv/bin/python",
+        "python.linting.pylintPath": "/home/vscode/.local/ha-venv/bin/pylint",
         "python.terminal.activateEnvInCurrentTerminal": true,
         "python.testing.pytestArgs": ["--no-cov"],
         "pylint.importStrategy": "fromEnvironment",

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@ __pycache__/
 *.pyc
 *.pyo
 .venv/
-.vscode/
+.vscode/*
+!.vscode/settings.default.json
 .idea/
 dev-config/
 .secrets/

--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -1,0 +1,5 @@
+{
+  "python.defaultInterpreterPath": "/home/vscode/.local/ha-venv/bin/python",
+  "python.linting.pylintPath": "/home/vscode/.local/ha-venv/bin/pylint",
+  "pylint.importStrategy": "fromEnvironment"
+}

--- a/script/setup
+++ b/script/setup
@@ -9,6 +9,9 @@ PIP="$VENV_DIR/bin/pip"
 
 cd "$REPO_ROOT"
 
+# Mark the repository as safe for Git inside the container
+git config --global --add safe.directory "$REPO_ROOT"
+
 # Create the venv VS Code/devcontainer is configured to use
 if [ ! -x "$PY" ]; then
   echo "Creating virtualenv at $VENV_DIR ..."


### PR DESCRIPTION
## Summary
- run setup when dev container is created
- run bootstrap when dev container starts
- configure VS Code to use Pylint from project virtualenv
- centralize git-safe-directory config in setup script
- track workspace settings to point VS Code at the project venv
- provide default VS Code settings file to avoid conflicts

## Testing
- `pre-commit run --files .gitignore .vscode/settings.default.json .devcontainer/devcontainer.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8996b82908326ae999bc454ac7da1