### PR TITLE
Add python-envs pythonProjects setting

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -39,6 +39,7 @@
         "pylint.path": ["/home/vscode/.local/ha-venv/bin/pylint"],
         "python.terminal.activateEnvInCurrentTerminal": true,
         "python.testing.pytestArgs": ["--no-cov"],
+        "python-envs.pythonProjects": [],
         "editor.formatOnPaste": false,
         "editor.formatOnSave": true,
         "editor.formatOnType": true,


### PR DESCRIPTION
## Summary
- set `python-envs.pythonProjects` to empty list in devcontainer so Python extension does not mis-identify project roots

## Testing
- `pre-commit run --files .devcontainer/devcontainer.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9910105e483269741586c2a6a631d