### PR TITLE
Add VS Code launch configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@ __pycache__/
 *.pyc
 *.pyo
 .venv/
-.vscode/
+.vscode/*
+!.vscode/launch.json
 .idea/
 dev-config/
 .secrets/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,74 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Home Assistant",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "homeassistant",
+      "justMyCode": false,
+      "args": ["--debug", "-c", "dev-config"]
+    },
+    {
+      "name": "Home Assistant (skip pip)",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "homeassistant",
+      "justMyCode": false,
+      "args": ["--debug", "-c", "dev-config", "--skip-pip"]
+    },
+    {
+      "name": "Home Assistant: Changed tests",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "justMyCode": false,
+      "args": ["--picked"]
+    },
+    {
+      "name": "Home Assistant: Debug Current Test File",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "console": "integratedTerminal",
+      "args": ["-vv", "${file}"]
+    },
+    {
+      // Debug by attaching to local Home Assistant server using Remote Python Debugger.
+      // See https://www.home-assistant.io/integrations/debugpy/
+      "name": "Home Assistant: Attach Local",
+      "type": "debugpy",
+      "request": "attach",
+      "connect": {
+        "port": 5678,
+        "host": "localhost"
+      },
+      "pathMappings": [
+        {
+          "localRoot": "${workspaceFolder}",
+          "remoteRoot": "."
+        }
+      ]
+    },
+    {
+      // Debug by attaching to remote Home Assistant server using Remote Python Debugger.
+      // See https://www.home-assistant.io/integrations/debugpy/
+      "name": "Home Assistant: Attach Remote",
+      "type": "debugpy",
+      "request": "attach",
+      "connect": {
+        "port": 5678,
+        "host": "homeassistant.local"
+      },
+      "pathMappings": [
+        {
+          "localRoot": "${workspaceFolder}",
+          "remoteRoot": "/usr/src/homeassistant"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add VS Code launch.json for debugging Home Assistant
- allow committing .vscode/launch.json via .gitignore

## Testing
- `pre-commit run --files .gitignore .vscode/launch.json`
- `pytest` *(fails: ModuleNotFoundError: No module named 'custom_components.kippy'; 'custom_components' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ad1aab688326974e0dcf7ad0c256