### PR TITLE
test: add backup API test when credentials missing

### DIFF
--- a/custom_components/kippy/const.py
+++ b/custom_components/kippy/const.py
@@ -56,7 +56,7 @@ LOGIN_SENSITIVE_FIELDS = {
 
 # Credential values that should be treated as absent. Tests use this set to
 # decide when to exercise a fake API rather than the real service.
-MISSING_CREDENTIAL_SENTINELS = {None, "", "<REDACTED>"}
+MISSING_CREDENTIAL_PLACEHOLDERS = {None, "", "<REDACTED>"}
 
 with resources.files(__package__).joinpath("translations/en.json").open(
     "r", encoding="utf-8"

--- a/custom_components/kippy/const.py
+++ b/custom_components/kippy/const.py
@@ -54,6 +54,10 @@ LOGIN_SENSITIVE_FIELDS = {
     "login_password_hash_md5",
 }
 
+# Credential values that should be treated as absent. Tests use this set to
+# decide when to exercise a fake API rather than the real service.
+MISSING_CREDENTIAL_SENTINELS = {None, "", "<REDACTED>"}
+
 with resources.files(__package__).joinpath("translations/en.json").open(
     "r", encoding="utf-8"
 ) as _trans_file:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = -s -vv -rA
+log_cli = true
+log_cli_level = INFO

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,7 +19,7 @@ import pytest_asyncio
 from dotenv import load_dotenv
 
 from custom_components.kippy.api import KippyApi
-from custom_components.kippy.const import MISSING_CREDENTIAL_SENTINELS
+from custom_components.kippy.const import MISSING_CREDENTIAL_PLACEHOLDERS
 
 SECRETS_FILE = Path(__file__).resolve().parents[1] / ".secrets" / "kippy.env"
 
@@ -30,7 +30,7 @@ EMAIL = os.getenv("KIPPY_EMAIL")
 PASSWORD = os.getenv("KIPPY_PASSWORD")
 
 # Treat empty or placeholder credential values as missing so tests use the fake API.
-CREDS = not any(value in MISSING_CREDENTIAL_SENTINELS for value in (EMAIL, PASSWORD))
+CREDS = not any(value in MISSING_CREDENTIAL_PLACEHOLDERS for value in (EMAIL, PASSWORD))
 
 
 class _FakeKippyApi:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -44,7 +44,10 @@ class _FakeKippyApi:
     app_verification_code = "FAKE_VERIFICATION_CODE"
 
     async def get_pet_kippy_list(self) -> list:
-        return []
+        return [
+            {"petID": "12345", "name": "Fido", "petKind": "4"},
+            {"petID": "54321", "name": "Fluffy", "petKind": "3"},
+        ]
 
     async def kippymap_action(self, *args, **kwargs) -> dict:  # noqa: D401
         return {"fake": True}
@@ -96,6 +99,16 @@ async def test_get_pet_kippy_list_returns_list(api):
     pets = await api.get_pet_kippy_list()
     if getattr(api, "is_fake", False):
         log.info("Fake API returned %d pets", len(pets))
+        assert any(
+            pet["name"] == "Fido" and pet["petID"] == "12345" and pet["petKind"] == "4"
+            for pet in pets
+        )
+        assert any(
+            pet["name"] == "Fluffy"
+            and pet["petID"] == "54321"
+            and pet["petKind"] == "3"
+            for pet in pets
+        )
     else:
         log.info("Real API returned %d pets", len(pets))
     assert isinstance(pets, list)
@@ -113,9 +126,9 @@ async def test_kippymap_action_and_activity_categories(api):
 
     if getattr(api, "is_fake", False):
         log.info("Fake API: verifying placeholder location and activity responses")
-        assert pets == []
-        location = await api.kippymap_action(0)
-        activity = await api.get_activity_categories(0, "", "", 0, 0)
+        assert any(pet["petID"] == "12345" for pet in pets)
+        location = await api.kippymap_action(12345)
+        activity = await api.get_activity_categories(12345, "", "", 0, 0)
         log.info("Fake location response: %s", location)
         log.info("Fake activity response: %s", activity)
         assert location == {"fake": True}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,9 +1,20 @@
+"""Tests for the Kippy API.
+
+These tests normally exercise the real API using credentials supplied via
+environment variables.  When those credentials are not available we still run
+the tests using a small in-memory fake so that it is obvious a placeholder test
+executed instead of silently skipping the entire module.
+"""
+
+from __future__ import annotations
+
 import os
 from datetime import datetime, timedelta
 from pathlib import Path
 
 import aiohttp
 import pytest
+import pytest_asyncio
 from dotenv import load_dotenv
 
 from custom_components.kippy.api import KippyApi
@@ -15,64 +26,92 @@ if SECRETS_FILE.exists():
 
 EMAIL = os.getenv("KIPPY_EMAIL")
 PASSWORD = os.getenv("KIPPY_PASSWORD")
-
-pytestmark = pytest.mark.skipif(
-    not (EMAIL and PASSWORD), reason="Missing KIPPY_EMAIL/KIPPY_PASSWORD secrets"
-)
+CREDS = bool(EMAIL and PASSWORD)
 
 
-async def _create_api() -> KippyApi:
-    session = aiohttp.ClientSession()
-    api = await KippyApi.async_create(session)
-    await api.login(EMAIL, PASSWORD, force=True)
-    return api
+class _FakeKippyApi:
+    """Fallback API used when no credentials are provided."""
+
+    app_code = "FAKE_CODE"
+    app_verification_code = "FAKE_VERIFICATION_CODE"
+
+    async def get_pet_kippy_list(self) -> list:
+        return []
+
+    async def kippymap_action(self, *args, **kwargs) -> dict:  # noqa: D401
+        return {"fake": True}
+
+    async def get_activity_categories(self, *args, **kwargs) -> dict:
+        return {"fake": True}
+
+
+@pytest_asyncio.fixture
+async def api():
+    """Return a real or fake API depending on the available credentials."""
+
+    if CREDS:
+        session = aiohttp.ClientSession()
+        api = await KippyApi.async_create(session)
+        await api.login(EMAIL, PASSWORD, force=True)
+        try:
+            yield api
+        finally:
+            await api._session.close()
+    else:
+        yield _FakeKippyApi()
 
 
 @pytest.mark.asyncio
-async def test_login_succeeds():
-    api = await _create_api()
-    try:
-        assert api.app_code is not None
-        assert api.app_verification_code is not None
-    finally:
-        await api._session.close()
+async def test_login_succeeds(api):
+    """Ensure login provides the expected codes or fake identifiers."""
+
+    assert api.app_code is not None
+    assert api.app_verification_code is not None
+
+    if not CREDS:
+        # Make it clear we ran the artificial fallback tests.
+        assert api.app_code == "FAKE_CODE"
+        assert api.app_verification_code == "FAKE_VERIFICATION_CODE"
 
 
 @pytest.mark.asyncio
-async def test_get_pet_kippy_list_returns_list():
-    api = await _create_api()
-    try:
-        pets = await api.get_pet_kippy_list()
-        assert isinstance(pets, list)
-    finally:
-        await api._session.close()
+async def test_get_pet_kippy_list_returns_list(api):
+    """The pet list should always be a list, even for the fake API."""
+
+    pets = await api.get_pet_kippy_list()
+    assert isinstance(pets, list)
 
 
 @pytest.mark.asyncio
-async def test_kippymap_action_and_activity_categories():
-    api = await _create_api()
-    try:
-        pets = await api.get_pet_kippy_list()
-        if not pets:
-            pytest.skip("No pets available for account")
-        pet = pets[0]
-        kippy_id = (
-            pet.get("kippy_id")
-            or pet.get("device_kippy_id")
-            or pet.get("deviceID")
-            or pet.get("deviceId")
+async def test_kippymap_action_and_activity_categories(api):
+    """Exercise Kippy Map and activity endpoints when possible.
+
+    For the fake API this simply confirms the placeholder values to make the
+    intent explicit.
+    """
+
+    pets = await api.get_pet_kippy_list()
+
+    if not pets or not CREDS:
+        assert pets == []
+        return
+
+    pet = pets[0]
+    kippy_id = (
+        pet.get("kippy_id")
+        or pet.get("device_kippy_id")
+        or pet.get("deviceID")
+        or pet.get("deviceId")
+    )
+    if kippy_id:
+        location = await api.kippymap_action(int(kippy_id), do_sms=False)
+        assert isinstance(location, dict)
+    pet_id = pet.get("petID") or pet.get("id")
+    if pet_id:
+        today = datetime.utcnow().date()
+        from_date = (today - timedelta(days=7)).strftime("%Y-%m-%d")
+        to_date = today.strftime("%Y-%m-%d")
+        activity = await api.get_activity_categories(
+            int(pet_id), from_date, to_date, 1, 1
         )
-        if kippy_id:
-            location = await api.kippymap_action(int(kippy_id), do_sms=False)
-            assert isinstance(location, dict)
-        pet_id = pet.get("petID") or pet.get("id")
-        if pet_id:
-            today = datetime.utcnow().date()
-            from_date = (today - timedelta(days=7)).strftime("%Y-%m-%d")
-            to_date = today.strftime("%Y-%m-%d")
-            activity = await api.get_activity_categories(
-                int(pet_id), from_date, to_date, 1, 1
-            )
-            assert isinstance(activity, dict)
-    finally:
-        await api._session.close()
+        assert isinstance(activity, dict)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,6 +19,7 @@ import pytest_asyncio
 from dotenv import load_dotenv
 
 from custom_components.kippy.api import KippyApi
+from custom_components.kippy.const import MISSING_CREDENTIAL_SENTINELS
 
 SECRETS_FILE = Path(__file__).resolve().parents[1] / ".secrets" / "kippy.env"
 
@@ -28,9 +29,8 @@ if SECRETS_FILE.exists():
 EMAIL = os.getenv("KIPPY_EMAIL")
 PASSWORD = os.getenv("KIPPY_PASSWORD")
 
-# Treat empty or redacted credential values as missing so tests use the fake API.
-PLACEHOLDER_VALUES = {None, "", "<REDACTED>"}
-CREDS = not any(value in PLACEHOLDER_VALUES for value in (EMAIL, PASSWORD))
+# Treat empty or placeholder credential values as missing so tests use the fake API.
+CREDS = not any(value in MISSING_CREDENTIAL_SENTINELS for value in (EMAIL, PASSWORD))
 
 
 class _FakeKippyApi:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -60,12 +60,10 @@ async def api():
         api.is_fake = False
         await api.login(EMAIL, PASSWORD, force=True)
         try:
-            print("Using real Kippy API for tests")
             yield api
         finally:
             await api._session.close()
     else:
-        print("Using in-memory fake Kippy API for tests")
         yield _FakeKippyApi()
 
 
@@ -80,9 +78,6 @@ async def test_login_succeeds(api):
         # Make it clear we ran the artificial fallback tests.
         assert api.app_code == "FAKE_CODE"
         assert api.app_verification_code == "FAKE_VERIFICATION_CODE"
-        print("Login test executed with fake credentials")
-    else:
-        print("Login test executed with real credentials")
 
 
 @pytest.mark.asyncio
@@ -91,10 +86,6 @@ async def test_get_pet_kippy_list_returns_list(api):
 
     pets = await api.get_pet_kippy_list()
     assert isinstance(pets, list)
-    if getattr(api, "is_fake", False):
-        print("Pet list test executed with fake API")
-    else:
-        print(f"Pet list test executed with real API and retrieved {len(pets)} pets")
 
 
 @pytest.mark.asyncio
@@ -113,7 +104,6 @@ async def test_kippymap_action_and_activity_categories(api):
         activity = await api.get_activity_categories(0, "", "", 0, 0)
         assert location == {"fake": True}
         assert activity == {"fake": True}
-        print("Endpoint test executed with fake API")
         return
 
     if not pets:
@@ -139,4 +129,3 @@ async def test_kippymap_action_and_activity_categories(api):
             int(pet_id), from_date, to_date, 1, 1
         )
         assert isinstance(activity, dict)
-    print("Endpoint test executed with real API")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,9 +1,10 @@
 """Tests for the Kippy API.
 
 These tests normally exercise the real API using credentials supplied via
-environment variables.  When those credentials are not available we still run
-the tests using a small in-memory fake so that it is obvious a placeholder test
-executed instead of silently skipping the entire module.
+environment variables. When those credentials are not available, or are
+placeholder values like ``"<REDACTED>"``, we still run the tests using a small
+in-memory fake so that it is obvious a placeholder test executed instead of
+silently skipping the entire module.
 """
 
 from __future__ import annotations
@@ -26,7 +27,10 @@ if SECRETS_FILE.exists():
 
 EMAIL = os.getenv("KIPPY_EMAIL")
 PASSWORD = os.getenv("KIPPY_PASSWORD")
-CREDS = bool(EMAIL and PASSWORD)
+
+# Treat empty or redacted credential values as missing so tests use the fake API.
+PLACEHOLDER_VALUES = {None, "", "<REDACTED>"}
+CREDS = not any(value in PLACEHOLDER_VALUES for value in (EMAIL, PASSWORD))
 
 
 class _FakeKippyApi:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -60,6 +60,7 @@ async def api():
         api.is_fake = False
         await api.login(EMAIL, PASSWORD, force=True)
         try:
+            print("Using real Kippy API for tests")
             yield api
         finally:
             await api._session.close()
@@ -79,6 +80,9 @@ async def test_login_succeeds(api):
         # Make it clear we ran the artificial fallback tests.
         assert api.app_code == "FAKE_CODE"
         assert api.app_verification_code == "FAKE_VERIFICATION_CODE"
+        print("Login test executed with fake credentials")
+    else:
+        print("Login test executed with real credentials")
 
 
 @pytest.mark.asyncio
@@ -87,6 +91,10 @@ async def test_get_pet_kippy_list_returns_list(api):
 
     pets = await api.get_pet_kippy_list()
     assert isinstance(pets, list)
+    if getattr(api, "is_fake", False):
+        print("Pet list test executed with fake API")
+    else:
+        print(f"Pet list test executed with real API and retrieved {len(pets)} pets")
 
 
 @pytest.mark.asyncio
@@ -105,6 +113,7 @@ async def test_kippymap_action_and_activity_categories(api):
         activity = await api.get_activity_categories(0, "", "", 0, 0)
         assert location == {"fake": True}
         assert activity == {"fake": True}
+        print("Endpoint test executed with fake API")
         return
 
     if not pets:
@@ -130,3 +139,4 @@ async def test_kippymap_action_and_activity_categories(api):
             int(pet_id), from_date, to_date, 1, 1
         )
         assert isinstance(activity, dict)
+    print("Endpoint test executed with real API")


### PR DESCRIPTION
## Summary
- ensure API tests run even without credentials by using a fake API fallback

## Testing
- `pre-commit run --files tests/test_api.py`
- `pytest tests/test_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68baccb0f824832697a4de8cac5b9e7f