### PR TITLE
Handle malformed request return code

### DIFF
--- a/custom_components/kippy/const.py
+++ b/custom_components/kippy/const.py
@@ -50,10 +50,27 @@ ACTIVITY_ID = SimpleNamespace(ALL=0)
 RETURN_VALUES = SimpleNamespace(
     SUCCESS=0,
     SUCCESS_TRUE=True,
+    MALFORMED_REQUEST=4,
     TOKEN_EXPIRED=6,
     UNAUTHORIZED=113,
     INVALID_CREDENTIALS=108,
 )
+
+# Return codes grouped by outcome.
+RETURN_CODES_SUCCESS = {
+    RETURN_VALUES.SUCCESS,
+    RETURN_VALUES.SUCCESS_TRUE,
+}
+
+# Mapping of failure codes to human readable errors.
+RETURN_CODE_ERRORS = {
+    RETURN_VALUES.MALFORMED_REQUEST: "Malformed request",
+    RETURN_VALUES.TOKEN_EXPIRED: "Session token expired",
+    RETURN_VALUES.UNAUTHORIZED: "Unauthorized",
+    RETURN_VALUES.INVALID_CREDENTIALS: "Invalid credentials",
+}
+
+RETURN_CODES_FAILURE = set(RETURN_CODE_ERRORS)
 
 # Fields to redact from logs.
 SENSITIVE_LOG_FIELDS = {"app_code", "app_verification_code", "petID", "auth_token"}

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,4 +1,4 @@
-from custom_components.kippy.api import _treat_401_as_success
+from custom_components.kippy.api import _return_code_error, _treat_401_as_success
 from custom_components.kippy.const import RETURN_VALUES
 
 
@@ -9,4 +9,21 @@ def test_return_code_unauthorized_not_success():
 def test_return_code_invalid_credentials_not_success():
     assert not _treat_401_as_success(
         "/path", {"return": RETURN_VALUES.INVALID_CREDENTIALS}
+    )
+
+
+def test_return_code_malformed_request_not_success():
+    assert not _treat_401_as_success(
+        "/path", {"return": RETURN_VALUES.MALFORMED_REQUEST}
+    )
+
+
+def test_error_message_for_unknown_code():
+    assert _return_code_error(999) == "Unknown error code 999"
+
+
+def test_error_message_for_known_code():
+    assert (
+        _return_code_error(RETURN_VALUES.INVALID_CREDENTIALS)
+        == "Invalid credentials (code 108)"
     )


### PR DESCRIPTION
## Summary
- define RETURN_VALUES.MALFORMED_REQUEST (4) for malformed request bodies
- ensure malformed request codes surface readable errors and are treated as failures
- surface human-readable errors for API return codes and group successes separately
- cover return code errors and unknown code fallback with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bae84feb9083269af88095464ba8ae