### PR TITLE
Remove token references

### DIFF
--- a/custom_components/kippy/const.py
+++ b/custom_components/kippy/const.py
@@ -50,9 +50,8 @@ ACTIVITY_ID = SimpleNamespace(ALL=0)
 RETURN_VALUES = SimpleNamespace(
     SUCCESS=0,
     SUCCESS_TRUE=True,
-    MALFORMED_REQUEST=4,
-    TOKEN_EXPIRED=6,
-    UNAUTHORIZED=113,
+    MALFORMED_REQUEST=[4, 13],
+    AUTHORIZATION_EXPIRED=6,
     INVALID_CREDENTIALS=108,
 )
 
@@ -64,16 +63,15 @@ RETURN_CODES_SUCCESS = {
 
 # Mapping of failure codes to human readable errors.
 RETURN_CODE_ERRORS = {
-    RETURN_VALUES.MALFORMED_REQUEST: "Malformed request",
-    RETURN_VALUES.TOKEN_EXPIRED: "Session token expired",
-    RETURN_VALUES.UNAUTHORIZED: "Unauthorized",
+    **{code: "Malformed request" for code in RETURN_VALUES.MALFORMED_REQUEST},
+    RETURN_VALUES.AUTHORIZATION_EXPIRED: "Authorization expired",
     RETURN_VALUES.INVALID_CREDENTIALS: "Invalid credentials",
 }
 
 RETURN_CODES_FAILURE = set(RETURN_CODE_ERRORS)
 
 # Fields to redact from logs.
-SENSITIVE_LOG_FIELDS = {"app_code", "app_verification_code", "petID", "auth_token"}
+SENSITIVE_LOG_FIELDS = {"app_code", "app_verification_code", "petID"}
 LOGIN_SENSITIVE_FIELDS = {
     "login_email",
     "login_password_hash",

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -2,19 +2,14 @@ from custom_components.kippy.api import _return_code_error, _treat_401_as_succes
 from custom_components.kippy.const import RETURN_VALUES
 
 
-def test_return_code_unauthorized_not_success():
-    assert not _treat_401_as_success("/path", {"return": RETURN_VALUES.UNAUTHORIZED})
+def test_return_code_malformed_request_not_success():
+    for code in RETURN_VALUES.MALFORMED_REQUEST:
+        assert not _treat_401_as_success("/path", {"return": code})
 
 
 def test_return_code_invalid_credentials_not_success():
     assert not _treat_401_as_success(
         "/path", {"return": RETURN_VALUES.INVALID_CREDENTIALS}
-    )
-
-
-def test_return_code_malformed_request_not_success():
-    assert not _treat_401_as_success(
-        "/path", {"return": RETURN_VALUES.MALFORMED_REQUEST}
     )
 
 
@@ -26,4 +21,16 @@ def test_error_message_for_known_code():
     assert (
         _return_code_error(RETURN_VALUES.INVALID_CREDENTIALS)
         == "Invalid credentials (code 108)"
+    )
+
+
+def test_error_message_for_malformed_request():
+    for code in RETURN_VALUES.MALFORMED_REQUEST:
+        assert _return_code_error(code) == f"Malformed request (code {code})"
+
+
+def test_error_message_for_authorization_expired():
+    assert (
+        _return_code_error(RETURN_VALUES.AUTHORIZATION_EXPIRED)
+        == "Authorization expired (code 6)"
     )

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -5,16 +5,16 @@ from custom_components.kippy.api import _redact, _redact_json
 
 def test_redact_json_handles_nested_fields():
     payload = {
-        "data": [{"petID": "123", "info": {"auth_token": "abc"}}],
-        "auth_token": "def",
+        "data": [{"petID": "123", "info": {"app_code": "abc"}}],
+        "app_code": "def",
     }
     redacted = _redact_json(json.dumps(payload))
     assert '"petID": "***"' in redacted
-    assert '"auth_token": "***"' in redacted
+    assert '"app_code": "***"' in redacted
 
 
 def test_redact_handles_nested_fields():
-    payload = {"outer": {"app_code": "xyz", "list": [{"auth_token": "abc"}]}}
+    payload = {"outer": {"app_code": "xyz", "list": [{"petID": "123"}]}}
     redacted = _redact(payload)
     assert redacted["outer"]["app_code"] == "***"
-    assert redacted["outer"]["list"][0]["auth_token"] == "***"
+    assert redacted["outer"]["list"][0]["petID"] == "***"


### PR DESCRIPTION
## Summary
- strip token/login_token handling from login flow
- drop session token constants and error codes
- add AUTHORIZATION_EXPIRED return value and token_device placeholder
- unify malformed request codes 4 and 13 under a single constant

## Testing
- `pre-commit run --files custom_components/kippy/const.py tests/test_error_handling.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baf5ed7edc8326808d41eaf2ed0480