### PR TITLE
Handle kippymap response for inactive subscription

### DIFF
--- a/custom_components/kippy/const.py
+++ b/custom_components/kippy/const.py
@@ -50,6 +50,9 @@ ACTIVITY_ID = SimpleNamespace(ALL=0)
 RETURN_VALUES = SimpleNamespace(
     SUCCESS=0,
     SUCCESS_TRUE=True,
+    # Returned when a kippymap action is performed on a device without an
+    # active subscription.
+    SUBSCRIPTION_FAILURE=False,
     MALFORMED_REQUEST=[4, 13],
     AUTHORIZATION_EXPIRED=6,
     INVALID_CREDENTIALS=108,
@@ -66,6 +69,7 @@ RETURN_CODE_ERRORS = {
     **{code: "Malformed request" for code in RETURN_VALUES.MALFORMED_REQUEST},
     RETURN_VALUES.AUTHORIZATION_EXPIRED: "Authorization expired",
     RETURN_VALUES.INVALID_CREDENTIALS: "Invalid credentials",
+    RETURN_VALUES.SUBSCRIPTION_FAILURE: "Subscription inactive",
 }
 
 RETURN_CODES_FAILURE = set(RETURN_CODE_ERRORS)

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -13,6 +13,12 @@ def test_return_code_invalid_credentials_not_success():
     )
 
 
+def test_return_code_subscription_failure_not_success():
+    assert not _treat_401_as_success(
+        "/path", {"return": RETURN_VALUES.SUBSCRIPTION_FAILURE}
+    )
+
+
 def test_error_message_for_unknown_code():
     assert _return_code_error(999) == "Unknown error code 999"
 
@@ -33,4 +39,11 @@ def test_error_message_for_authorization_expired():
     assert (
         _return_code_error(RETURN_VALUES.AUTHORIZATION_EXPIRED)
         == "Authorization expired (code 6)"
+    )
+
+
+def test_error_message_for_subscription_failure():
+    assert (
+        _return_code_error(RETURN_VALUES.SUBSCRIPTION_FAILURE)
+        == "Subscription inactive (code False)"
     )


### PR DESCRIPTION
## Summary
- treat `{ "return": false }` as a subscription failure
- expose `SUBSCRIPTION_FAILURE` code and surface as a mapped error
- handle return codes generically via success-code membership instead of special-casing subscription failures

## Testing
- `python -m pip install -r requirements-test.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb13efb9b883268a72194e5dce8635