### PR TITLE
fix: normalize API return codes

### DIFF
--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -19,6 +19,14 @@ def test_return_code_subscription_failure_not_success():
     )
 
 
+def test_return_code_success_string():
+    assert _treat_401_as_success("/path", {"return": "0"})
+
+
+def test_return_code_invalid_credentials_string_not_success():
+    assert not _treat_401_as_success("/path", {"return": "108"})
+
+
 def test_error_message_for_unknown_code():
     assert _return_code_error(999) == "Unknown error code 999"
 


### PR DESCRIPTION
## Summary
- normalize API return codes to integers to handle string responses
- test return code handling for string payloads

## Testing
- `pre-commit run --files custom_components/kippy/api.py tests/test_error_handling.py`
- `pytest`
- `python -m script.hassfest --integration-path custom_components/kippy` *(fails: No module named script.hassfest)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5aec3f9c8326b05b7058ecd3c134