### PR TITLE
Expose energy saving operating status

### DIFF
--- a/custom_components/kippy/const.py
+++ b/custom_components/kippy/const.py
@@ -97,9 +97,18 @@ ERROR_NO_AUTH_DATA = _TRANSLATIONS["error"]["no_auth_data"]
 LABEL_EXPIRED = _TRANSLATIONS["common"]["expired"]
 
 # Mapping of operating status codes returned by the API.
-OPERATING_STATUS_IDLE = 1
-OPERATING_STATUS_LIVE = 5
-OPERATING_STATUS_POWER_SAVING = 18
+OPERATING_STATUS = SimpleNamespace(
+    IDLE=1,
+    LIVE=5,
+    ENERGY_SAVING=18,
+)
+
+# Mapping of operating status codes to their human readable string.
+OPERATING_STATUS_MAP: dict[int, str] = {
+    OPERATING_STATUS.IDLE: "idle",
+    OPERATING_STATUS.LIVE: "live",
+    OPERATING_STATUS.ENERGY_SAVING: "energy_saving",
+}
 
 # Names used by the API for location technologies.
 LOCALIZATION_TECHNOLOGY_LBS = "LBS (Low accuracy)"

--- a/custom_components/kippy/coordinator.py
+++ b/custom_components/kippy/coordinator.py
@@ -10,7 +10,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import KippyApi
-from .const import DOMAIN, LOCALIZATION_TECHNOLOGY_LBS, OPERATING_STATUS_LIVE
+from .const import (
+    DOMAIN,
+    LOCALIZATION_TECHNOLOGY_LBS,
+    OPERATING_STATUS,
+    OPERATING_STATUS_MAP,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -101,13 +106,17 @@ class KippyMapDataUpdateCoordinator(DataUpdateCoordinator):
 
         operating_status = data.get("operating_status")
         try:
-            operating_status = int(operating_status)
+            operating_status_int = int(operating_status)
         except (TypeError, ValueError):
-            operating_status = None
-        if operating_status == OPERATING_STATUS_LIVE:
+            operating_status_int = None
+
+        operating_status_str = OPERATING_STATUS_MAP.get(operating_status_int)
+        if operating_status_int == OPERATING_STATUS.LIVE:
             self.update_interval = timedelta(seconds=self.live_refresh)
         else:
             self.update_interval = timedelta(seconds=self.idle_refresh)
+
+        data["operating_status"] = operating_status_str
         return data
 
     async def async_set_idle_refresh(self, value: int) -> None:
@@ -115,11 +124,7 @@ class KippyMapDataUpdateCoordinator(DataUpdateCoordinator):
         self.idle_refresh = value
         if self.data:
             operating_status = self.data.get("operating_status")
-            try:
-                operating_status = int(operating_status)
-            except (TypeError, ValueError):
-                operating_status = None
-            if operating_status != OPERATING_STATUS_LIVE:
+            if operating_status != OPERATING_STATUS_MAP[OPERATING_STATUS.LIVE]:
                 self.update_interval = timedelta(seconds=self.idle_refresh)
 
     async def async_set_live_refresh(self, value: int) -> None:
@@ -127,11 +132,7 @@ class KippyMapDataUpdateCoordinator(DataUpdateCoordinator):
         self.live_refresh = value
         if self.data:
             operating_status = self.data.get("operating_status")
-            try:
-                operating_status = int(operating_status)
-            except (TypeError, ValueError):
-                operating_status = None
-            if operating_status == OPERATING_STATUS_LIVE:
+            if operating_status == OPERATING_STATUS_MAP[OPERATING_STATUS.LIVE]:
                 self.update_interval = timedelta(seconds=self.live_refresh)
 
 

--- a/custom_components/kippy/sensor.py
+++ b/custom_components/kippy/sensor.py
@@ -55,6 +55,7 @@ async def async_setup_entry(
             entities.append(KippyFixTimeSensor(map_coord, pet))
             entities.append(KippyGpsTimeSensor(map_coord, pet))
             entities.append(KippyLbsTimeSensor(map_coord, pet))
+            entities.append(KippyOperatingStatusSensor(map_coord, pet))
 
         entities.extend(
             [
@@ -530,3 +531,31 @@ class KippyLbsTimeSensor(_KippyBaseMapEntity, SensorEntity):
     @property
     def native_value(self) -> datetime | None:
         return self._get_datetime("lbs_time")
+
+
+class KippyOperatingStatusSensor(
+    CoordinatorEntity[KippyMapDataUpdateCoordinator], SensorEntity
+):
+    """Sensor indicating operating status."""
+
+    def __init__(
+        self, coordinator: KippyMapDataUpdateCoordinator, pet: dict[str, Any]
+    ) -> None:
+        super().__init__(coordinator)
+        self._pet_id = pet["petID"]
+        self._pet_name = pet.get("petName")
+        self._pet_data = pet
+        self._attr_name = (
+            f"{self._pet_name} Operating Status" if self._pet_name else "Operating Status"
+        )
+        self._attr_unique_id = f"{self._pet_id}_operating_status"
+        self._attr_translation_key = "operating_status"
+
+    @property
+    def native_value(self) -> Any:
+        return self.coordinator.data.get("operating_status") if self.coordinator.data else None
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        name = f"Kippy {self._pet_name}" if self._pet_name else "Kippy"
+        return build_device_info(self._pet_id, self._pet_data, name)

--- a/custom_components/kippy/strings.json
+++ b/custom_components/kippy/strings.json
@@ -34,12 +34,15 @@
           "on": "Yes",
           "off": "No"
         }
-      },
+      }
+    },
+    "sensor": {
       "operating_status": {
         "name": "Operating status",
         "state": {
-          "on": "Live",
-          "off": "Idle"
+          "live": "Live",
+          "idle": "Idle",
+          "energy_saving": "Energy saving"
         }
       }
     },

--- a/custom_components/kippy/switch.py
+++ b/custom_components/kippy/switch.py
@@ -12,7 +12,12 @@ from homeassistant.helpers.entity import EntityCategory
 from .helpers import build_device_info
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, LOCALIZATION_TECHNOLOGY_LBS, OPERATING_STATUS_LIVE
+from .const import (
+    DOMAIN,
+    LOCALIZATION_TECHNOLOGY_LBS,
+    OPERATING_STATUS,
+    OPERATING_STATUS_MAP,
+)
 from .coordinator import (
     KippyDataUpdateCoordinator,
     KippyMapDataUpdateCoordinator,
@@ -97,7 +102,8 @@ class KippyLiveTrackingSwitch(
     @property
     def is_on(self) -> bool:
         return bool(
-            self.coordinator.data.get("operating_status") == OPERATING_STATUS_LIVE
+            self.coordinator.data.get("operating_status")
+            == OPERATING_STATUS_MAP[OPERATING_STATUS.LIVE]
         )
 
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/custom_components/kippy/translations/en.json
+++ b/custom_components/kippy/translations/en.json
@@ -36,12 +36,15 @@
           "on": "Yes",
           "off": "No"
         }
-      },
+      }
+    },
+    "sensor": {
       "operating_status": {
         "name": "Operating status",
         "state": {
-          "on": "Live",
-          "off": "Idle"
+          "live": "Live",
+          "idle": "Idle",
+          "energy_saving": "Energy saving"
         }
       }
     },

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -3,7 +3,12 @@ from unittest.mock import MagicMock
 import pytest
 
 from custom_components.kippy.const import LABEL_EXPIRED, PET_KIND_TO_TYPE
-from custom_components.kippy.sensor import KippyExpiredDaysSensor, KippyPetTypeSensor
+from custom_components.kippy.const import OPERATING_STATUS, OPERATING_STATUS_MAP
+from custom_components.kippy.sensor import (
+    KippyExpiredDaysSensor,
+    KippyOperatingStatusSensor,
+    KippyPetTypeSensor,
+)
 
 
 @pytest.mark.asyncio
@@ -43,3 +48,20 @@ async def test_pet_type_sensor_maps_kind_to_type() -> None:
     sensor = KippyPetTypeSensor(coordinator, pet)
 
     assert sensor.native_value == PET_KIND_TO_TYPE["4"]
+
+
+@pytest.mark.asyncio
+async def test_operating_status_sensor_returns_string() -> None:
+    """Operating status sensor should expose a human readable value."""
+    pet = {"petID": "1"}
+    coordinator = MagicMock()
+    coordinator.data = {
+        "operating_status": OPERATING_STATUS_MAP[OPERATING_STATUS.ENERGY_SAVING]
+    }
+    coordinator.async_add_listener = MagicMock()
+    sensor = KippyOperatingStatusSensor(coordinator, pet)
+
+    assert (
+        sensor.native_value
+        == OPERATING_STATUS_MAP[OPERATING_STATUS.ENERGY_SAVING]
+    )


### PR DESCRIPTION
## Summary
- consolidate operating status codes into namespace with string mapping
- convert coordinator operating_status to human readable strings and adjust refresh rate
- add Operating Status sensor with energy saving state

## Testing
- `python -m script.hassfest --integration-path custom_components/kippy` (fails: No module named script.hassfest)
- `pytest` (fails: Cannot connect to host prod.kippyapi.eu:443 ssl:... [Network is unreachable])


------
https://chatgpt.com/codex/tasks/task_e_68bb6fc3c37483268d7b35239ecc2610