### PR TITLE
Auto-enable energy saving mode based on operating status

### DIFF
--- a/custom_components/kippy/button.py
+++ b/custom_components/kippy/button.py
@@ -60,7 +60,7 @@ class KippyPressButton(
 
     async def async_press(self) -> None:
         data = await self.coordinator.api.kippymap_action(self.coordinator.kippy_id)
-        self.coordinator.async_set_updated_data(data)
+        self.coordinator.process_new_data(data)
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/kippy/coordinator.py
+++ b/custom_components/kippy/coordinator.py
@@ -86,6 +86,10 @@ class KippyMapDataUpdateCoordinator(DataUpdateCoordinator):
             data = await self.api.kippymap_action(self.kippy_id)
         except Exception as err:  # noqa: BLE001
             raise UpdateFailed(f"Error communicating with API: {err}") from err
+        return self._process_data(data)
+
+    def _process_data(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Normalize raw kippymap data from the API."""
         if (
             self.ignore_lbs
             and data.get("localization_technology") == LOCALIZATION_TECHNOLOGY_LBS
@@ -125,6 +129,10 @@ class KippyMapDataUpdateCoordinator(DataUpdateCoordinator):
 
         data["operating_status"] = operating_status_str
         return data
+
+    def process_new_data(self, data: dict[str, Any]) -> None:
+        """Process raw data and update the coordinator state."""
+        self.async_set_updated_data(self._process_data(data))
 
     async def async_set_idle_refresh(self, value: int) -> None:
         """Update idle refresh value and interval when idle."""

--- a/custom_components/kippy/switch.py
+++ b/custom_components/kippy/switch.py
@@ -129,14 +129,14 @@ class KippyLiveTrackingSwitch(
         data = await self.coordinator.api.kippymap_action(
             self.coordinator.kippy_id, app_action=1
         )
-        self.coordinator.async_set_updated_data(data)
+        self.coordinator.process_new_data(data)
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         data = await self.coordinator.api.kippymap_action(
             self.coordinator.kippy_id, app_action=1
         )
-        self.coordinator.async_set_updated_data(data)
+        self.coordinator.process_new_data(data)
         self.async_write_ha_state()
 
     @property

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,22 @@
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.kippy.const import OPERATING_STATUS, OPERATING_STATUS_MAP
+from custom_components.kippy.coordinator import KippyMapDataUpdateCoordinator
+
+
+@pytest.mark.asyncio
+async def test_process_new_data_maps_operating_status() -> None:
+    """process_new_data should map numeric operating status codes."""
+    hass = MagicMock()
+    hass.loop = asyncio.get_running_loop()
+    coordinator = KippyMapDataUpdateCoordinator(hass, MagicMock(), MagicMock(), 1)
+
+    coordinator.process_new_data({"operating_status": OPERATING_STATUS.ENERGY_SAVING})
+
+    assert (
+        coordinator.data["operating_status"]
+        == OPERATING_STATUS_MAP[OPERATING_STATUS.ENERGY_SAVING]
+    )

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,33 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.kippy.const import OPERATING_STATUS, OPERATING_STATUS_MAP
+from custom_components.kippy.switch import KippyEnergySavingSwitch
+
+
+@pytest.mark.asyncio
+async def test_energy_saving_switch_updates_from_operating_status() -> None:
+    """Energy saving switch turns on when operating status is energy saving."""
+    pet = {"petID": "1", "energySavingMode": 0}
+
+    coordinator = MagicMock()
+    coordinator.data = {"pets": [pet]}
+    coordinator.async_add_listener = MagicMock(return_value=MagicMock())
+
+    map_coordinator = MagicMock()
+    map_coordinator.data = {
+        "operating_status": OPERATING_STATUS_MAP[OPERATING_STATUS.ENERGY_SAVING]
+    }
+    map_coordinator.async_add_listener = MagicMock(return_value=MagicMock())
+
+    switch = KippyEnergySavingSwitch(coordinator, pet, map_coordinator)
+    switch.async_write_ha_state = MagicMock()
+
+    assert not switch.is_on
+
+    switch._handle_map_update()
+
+    assert switch.is_on
+    assert pet["energySavingMode"] == 1
+


### PR DESCRIPTION
## Summary
- Ensure energy saving switch turns on when operating status reports `energy_saving`
- Add unit test verifying the switch updates when operating status changes

## Testing
- `python -m script.hassfest --integration-path custom_components/kippy` *(fails: No module named script.hassfest)*
- `pytest ./tests --cov=custom_components.kippy --cov-report term-missing` *(errors: Cannot connect to host prod.kippyapi.eu:443)*

------
https://chatgpt.com/codex/tasks/task_e_68bb795f7a5c8326a7271f8a61f09899