### PR TITLE
Skip real API tests when credentials are missing

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,7 +28,11 @@ if SECRETS_FILE.exists():
 EMAIL = os.getenv("KIPPY_EMAIL")
 PASSWORD = os.getenv("KIPPY_PASSWORD")
 
-if any(value in MISSING_CREDENTIAL_PLACEHOLDERS for value in (EMAIL, PASSWORD)):
+if (
+    not EMAIL
+    or not PASSWORD
+    or any(value in MISSING_CREDENTIAL_PLACEHOLDERS for value in (EMAIL, PASSWORD))
+):
     pytest.skip(
         "Kippy credentials are missing or redacted; skipping real API tests",
         allow_module_level=True,
@@ -146,6 +150,7 @@ async def test_kippymap_action_and_activity_categories_no_pets(
     monkeypatch.setattr(api, "get_pet_kippy_list", fake_get_pet_kippy_list)
 
     with pytest.raises(pytest.skip.Exception):
+        await test_kippymap_action_and_activity_categories(api)
 
 
 @pytest.mark.asyncio
@@ -160,6 +165,7 @@ async def test_kippymap_action_and_activity_categories_no_kippy_id(
     monkeypatch.setattr(api, "get_pet_kippy_list", fake_get_pet_kippy_list)
 
     with pytest.raises(pytest.skip.Exception):
+        await test_kippymap_action_and_activity_categories(api)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- skip real API tests when credential env vars are unset or placeholders
- ensure skip-path tests invoke shared test helper

## Testing
- `pre-commit run --files tests/test_api.py tests/test_api_fake.py`
- `pytest tests/test_api_fake.py --cov=tests.test_api_fake --cov-report term-missing`
- `pytest tests/test_api.py --cov=tests.test_api --cov-report term-missing`
- `pytest tests/test_api_fake.py tests/test_api.py`
- `python script/hassfest --integration-path custom_components/kippy`


------
https://chatgpt.com/codex/tasks/task_e_68bc3710b1e883268201c2d71e7d556c