### PR TITLE
Add integration refresh button and use pet ID as primary device identifier

### DIFF
--- a/custom_components/kippy/helpers.py
+++ b/custom_components/kippy/helpers.py
@@ -8,19 +8,21 @@ from .const import DOMAIN
 
 
 def build_device_info(pet_id: int | str, pet: dict[str, Any], name: str) -> DeviceInfo:
-    """Create a DeviceInfo object for a Kippy pet with IDs and IMEI."""
+    """Create a DeviceInfo object for a Kippy pet."""
     identifiers: set[tuple[str, str]] = {(DOMAIN, str(pet_id))}
     connections: set[tuple[str, str]] = set()
 
     kippy_id = pet.get("kippyID") or pet.get("kippy_id")
     if kippy_id:
-        identifiers.add((DOMAIN, str(kippy_id)))
         connections.add(("kippy_id", str(kippy_id)))
 
     kippy_imei = pet.get("kippyIMEI")
     if kippy_imei:
-        identifiers.add((DOMAIN, str(kippy_imei)))
         connections.add(("imei", str(kippy_imei)))
+
+    kippy_serial = pet.get("kippySerial")
+    if kippy_serial:
+        connections.add(("serial", str(kippy_serial)))
 
     return DeviceInfo(
         identifiers=identifiers,
@@ -29,5 +31,5 @@ def build_device_info(pet_id: int | str, pet: dict[str, Any], name: str) -> Devi
         manufacturer="Kippy",
         model=pet.get("kippyType"),
         sw_version=pet.get("kippyFirmware"),
-        serial_number=pet.get("kippySerial"),
+        serial_number=kippy_serial,
     )

--- a/custom_components/kippy/strings.json
+++ b/custom_components/kippy/strings.json
@@ -77,6 +77,9 @@
       },
       "refresh_activities": {
         "name": "Refresh activities"
+      },
+      "refresh_pets": {
+        "name": "Refresh pets"
       }
     }
   }

--- a/custom_components/kippy/translations/en.json
+++ b/custom_components/kippy/translations/en.json
@@ -79,6 +79,9 @@
       },
       "refresh_activities": {
         "name": "Refresh activities"
+      },
+      "refresh_pets": {
+        "name": "Refresh pets"
       }
     }
   }

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -5,6 +5,7 @@ import pytest
 from custom_components.kippy.button import (
     KippyActivityCategoriesButton,
     KippyPressButton,
+    KippyRefreshPetsButton,
     async_setup_entry,
 )
 from custom_components.kippy.const import DOMAIN
@@ -84,6 +85,7 @@ async def test_button_async_setup_entry_creates_entities() -> None:
     entities = async_add_entities.call_args[0][0]
     assert any(isinstance(e, KippyPressButton) for e in entities)
     assert any(isinstance(e, KippyActivityCategoriesButton) for e in entities)
+    assert any(isinstance(e, KippyRefreshPetsButton) for e in entities)
 
 
 @pytest.mark.asyncio
@@ -105,7 +107,10 @@ async def test_button_async_setup_entry_no_pets() -> None:
     }
     async_add_entities = MagicMock()
     await async_setup_entry(hass, entry, async_add_entities)
-    async_add_entities.assert_called_once_with([])
+    async_add_entities.assert_called_once()
+    entities = async_add_entities.call_args[0][0]
+    assert len(entities) == 1
+    assert isinstance(entities[0], KippyRefreshPetsButton)
 
 
 @pytest.mark.asyncio
@@ -127,7 +132,22 @@ async def test_button_async_setup_entry_missing_map() -> None:
     }
     async_add_entities = MagicMock()
     await async_setup_entry(hass, entry, async_add_entities)
-    async_add_entities.assert_called_once_with([])
+    async_add_entities.assert_called_once()
+    entities = async_add_entities.call_args[0][0]
+    assert len(entities) == 1
+    assert isinstance(entities[0], KippyRefreshPetsButton)
+
+
+@pytest.mark.asyncio
+async def test_refresh_pets_button_reloads_entry() -> None:
+    """Refresh pets button reloads the config entry."""
+    hass = MagicMock()
+    entry = MagicMock()
+    entry.entry_id = "1"
+    hass.config_entries.async_reload = AsyncMock()
+    button = KippyRefreshPetsButton(hass, entry)
+    await button.async_press()
+    hass.config_entries.async_reload.assert_called_once_with("1")
 
 
 def test_button_device_info_properties() -> None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,8 +1,9 @@
+from custom_components.kippy.const import DOMAIN
 from custom_components.kippy.helpers import build_device_info
 
 
 def test_build_device_info_with_ids() -> None:
-    """Ensure identifiers and connections include kippy ID and IMEI."""
+    """Ensure identifiers use pet ID and connections include device info."""
     pet = {
         "kippyID": 123,
         "kippyIMEI": "imei",
@@ -11,8 +12,10 @@ def test_build_device_info_with_ids() -> None:
         "kippySerial": "serial",
     }
     info = build_device_info(1, pet, "Name")
+    assert info["identifiers"] == {(DOMAIN, "1")}
     assert ("kippy_id", "123") in info["connections"]
     assert ("imei", "imei") in info["connections"]
+    assert ("serial", "serial") in info["connections"]
     assert info["name"] == "Name"
     assert info["model"] == "type"
     assert info["sw_version"] == "1"


### PR DESCRIPTION
## Summary
- add refresh button on integration to reload pet list
- track Kippy devices by pet ID only and allow kippy ID/IMEI/serial updates

## Testing
- `pre-commit run --files custom_components/kippy/helpers.py custom_components/kippy/button.py custom_components/kippy/strings.json custom_components/kippy/translations/en.json tests/test_button.py tests/test_helpers.py`
- `python script/hassfest --integration-path custom_components/kippy`
- `pytest ./tests --cov=custom_components.kippy --cov-report term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68bc47ccf180832695ac6a14b72e2045