### PR TITLE
Ensure codex script installs Python 3.13

### DIFF
--- a/script/codex.sh
+++ b/script/codex.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-pip install -r requirements.txt
+PYTHON="python3.13"
+if ! command -v "$PYTHON" >/dev/null 2>&1; then
+  echo "Installing Python 3.13..."
+  sudo apt-get update
+  sudo apt-get install -y python3.13 python3.13-venv
+fi
+
+"$PYTHON" -m pip install -r requirements.txt
 echo "Create .secrets/kippy.env"
 echo "Copy secrets KIPPY_CODEX_EMAIL and KIPPY_CODEX_PASSWORD"
 echo "to KIPPY_EMAIL and KIPPY_PASSWORD environment variables."


### PR DESCRIPTION
## Summary
- ensure script/codex.sh installs Python 3.13 if missing and use it for requirements

## Testing
- `pre-commit run --files script/codex.sh`
- `python script/hassfest --integration-path custom_components/kippy`
- `pytest ./tests --cov=custom_components.kippy --cov-report term-missing` *(fails: Cannot connect to host prod.kippyapi.eu)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6357d3f08326b7091fcc4f118410