### PR TITLE
Add modify settings API and GPS tracking switch

### DIFF
--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -400,7 +400,19 @@ class KippyApi:
         }
 
         data = await self._post_with_refresh(GET_PETS_PATH, payload, REQUEST_HEADERS)
-        return data.get("data", [])
+        pets = data.get("data", [])
+        for pet in pets:
+            if not isinstance(pet, dict):
+                continue
+            if "enableGPSOnDefault" in pet and "gpsOnDefault" not in pet:
+                value = pet.pop("enableGPSOnDefault")
+                if isinstance(value, str):
+                    try:
+                        value = int(value)
+                    except ValueError:
+                        value = 1 if value.lower() in ("true", "1") else 0
+                pet["gpsOnDefault"] = int(bool(value))
+        return pets
 
     async def kippymap_action(
         self,

--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -492,7 +492,8 @@ class KippyApi:
             "modify_kippy_id": kippy_id,
         }
         if update_frequency is not None:
-            payload["update_frequency"] = float(update_frequency)
+            # Ensure a single decimal place (e.g. ``1.0``) as required by the API
+            payload["update_frequency"] = float(f"{float(update_frequency):.1f}")
         if gps_on_default is not None:
             payload["gps_on_default"] = bool(gps_on_default)
         if energy_saving_mode is not None:

--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -479,7 +479,7 @@ class KippyApi:
         if update_frequency is not None:
             payload["update_frequency"] = float(update_frequency)
         if gps_on_default is not None:
-            payload["gps_on_default"] = str(bool(gps_on_default)).lower()
+            payload["gps_on_default"] = bool(gps_on_default)
         if energy_saving_mode is not None:
             payload["energy_saving_mode"] = int(energy_saving_mode)
 

--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -479,7 +479,7 @@ class KippyApi:
         if update_frequency is not None:
             payload["update_frequency"] = float(update_frequency)
         if gps_on_default is not None:
-            payload["gps_on_default"] = bool(gps_on_default)
+            payload["gps_on_default"] = str(bool(gps_on_default)).lower()
         if energy_saving_mode is not None:
             payload["energy_saving_mode"] = int(energy_saving_mode)
 

--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -224,7 +224,8 @@ class KippyApi:
         try:
             if _LOGGER.isEnabledFor(logging.DEBUG):
                 _LOGGER.debug(
-                    "Login request: %s", _redact(payload, LOGIN_SENSITIVE_FIELDS)
+                    "Login request: %s",
+                    json.dumps(_redact(payload, LOGIN_SENSITIVE_FIELDS)),
                 )
             async with self._session.post(
                 self._url(LOGIN_PATH),
@@ -241,7 +242,7 @@ class KippyApi:
                     _LOGGER.debug(
                         "Login failed: status=%s request=%s response=%s",
                         err.status,
-                        _redact(payload, LOGIN_SENSITIVE_FIELDS),
+                        json.dumps(_redact(payload, LOGIN_SENSITIVE_FIELDS)),
                         _redact_json(resp_text),
                     )
                     raise
@@ -252,7 +253,7 @@ class KippyApi:
                         _LOGGER.debug(
                             "Login failed: return=%s request=%s response=%s",
                             return_code,
-                            _redact(payload, LOGIN_SENSITIVE_FIELDS),
+                            json.dumps(_redact(payload, LOGIN_SENSITIVE_FIELDS)),
                             _redact_json(resp_text),
                         )
                         raise ClientResponseError(
@@ -266,7 +267,7 @@ class KippyApi:
                     _LOGGER.debug(
                         "Login failed: return=%s request=%s response=%s",
                         return_code,
-                        _redact(payload, LOGIN_SENSITIVE_FIELDS),
+                        json.dumps(_redact(payload, LOGIN_SENSITIVE_FIELDS)),
                         _redact_json(resp_text),
                     )
                     raise ClientResponseError(
@@ -279,7 +280,7 @@ class KippyApi:
         except ClientError as err:
             _LOGGER.debug(
                 "Error communicating with Kippy API: request=%s error=%s",
-                _redact(payload, LOGIN_SENSITIVE_FIELDS),
+                json.dumps(_redact(payload, LOGIN_SENSITIVE_FIELDS)),
                 err,
             )
             raise
@@ -314,7 +315,9 @@ class KippyApi:
         for attempt in range(2):
             try:
                 if _LOGGER.isEnabledFor(logging.DEBUG):
-                    _LOGGER.debug("%s request: %s", path, _redact(payload))
+                    _LOGGER.debug(
+                        "%s request: %s", path, json.dumps(_redact(payload))
+                    )
                 async with self._session.post(
                     self._url(path),
                     data=json.dumps(payload),
@@ -338,7 +341,7 @@ class KippyApi:
                             "%s failed: status=%s request=%s response=%s",
                             path,
                             err.status,
-                            _redact(payload),
+                            json.dumps(_redact(payload)),
                             _redact_json(resp_text),
                         )
                         if err.status == 401 and attempt == 0:
@@ -356,7 +359,7 @@ class KippyApi:
                         "%s failed: return=%s request=%s response=%s",
                         path,
                         return_code,
-                        _redact(payload),
+                        json.dumps(_redact(payload)),
                         _redact_json(resp_text),
                     )
                     if (
@@ -375,7 +378,7 @@ class KippyApi:
             except ClientError as err:
                 _LOGGER.debug(
                     "Error communicating with Kippy API: request=%s error=%s",
-                    _redact(payload),
+                    json.dumps(_redact(payload)),
                     err,
                 )
                 raise

--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -26,6 +26,7 @@ from .const import (
     GET_ACTIVITY_CATEGORIES_PATH,
     GET_PETS_PATH,
     KIPPYMAP_ACTION_PATH,
+    KIPPYMAP_MODIFY_SETTINGS_PATH,
     LOCALIZATION_TECHNOLOGY_MAP,
     LOGIN_PATH,
     LOGIN_SENSITIVE_FIELDS,
@@ -453,6 +454,38 @@ class KippyApi:
             )
 
         return payload
+
+    async def modify_kippy_settings(
+        self,
+        kippy_id: int,
+        *,
+        update_frequency: float | None = None,
+        gps_on_default: bool | None = None,
+        energy_saving_mode: bool | None = None,
+    ) -> Dict[str, Any]:
+        """Modify settings for a specific device."""
+
+        await self.ensure_login()
+
+        if not self._auth:
+            raise RuntimeError(ERROR_NO_AUTH_DATA)
+
+        payload: Dict[str, Any] = {
+            "app_code": self.app_code,
+            "app_verification_code": self.app_verification_code,
+            "app_identity": APP_IDENTITY,
+            "modify_kippy_id": kippy_id,
+        }
+        if update_frequency is not None:
+            payload["update_frequency"] = float(update_frequency)
+        if gps_on_default is not None:
+            payload["gps_on_default"] = bool(gps_on_default)
+        if energy_saving_mode is not None:
+            payload["energy_saving_mode"] = int(energy_saving_mode)
+
+        return await self._post_with_refresh(
+            KIPPYMAP_MODIFY_SETTINGS_PATH, payload, REQUEST_HEADERS
+        )
 
     async def get_activity_categories(
         self,

--- a/custom_components/kippy/const.py
+++ b/custom_components/kippy/const.py
@@ -21,6 +21,7 @@ DEFAULT_HOST = "https://prod.kippyapi.eu"
 LOGIN_PATH = "/v2/login.php"
 GET_PETS_PATH = "/v2/GetPetKippyList.php"
 KIPPYMAP_ACTION_PATH = "/v2/kippymap_action.php"
+KIPPYMAP_MODIFY_SETTINGS_PATH = "/v2/kippymap_modifyKippySettings.php"
 GET_ACTIVITY_CATEGORIES_PATH = "/v2/vita/get_activities_cat.php"
 
 # Default request headers.

--- a/custom_components/kippy/number.py
+++ b/custom_components/kippy/number.py
@@ -68,7 +68,15 @@ class KippyUpdateFrequencyNumber(CoordinatorEntity[KippyDataUpdateCoordinator], 
         return float(value) if value is not None else None
 
     async def async_set_native_value(self, value: float) -> None:
-        self._pet_data["updateFrequency"] = int(value)
+        kippy_id = self._pet_data.get("kippyID") or self._pet_data.get("kippy_id")
+        if kippy_id is not None:
+            data = await self.coordinator.api.modify_kippy_settings(
+                int(kippy_id), update_frequency=value
+            )
+            new_value = data.get("update_frequency", value)
+            self._pet_data["updateFrequency"] = int(new_value)
+        else:
+            self._pet_data["updateFrequency"] = int(value)
         self.async_write_ha_state()
 
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/kippy/number.py
+++ b/custom_components/kippy/number.py
@@ -69,9 +69,17 @@ class KippyUpdateFrequencyNumber(CoordinatorEntity[KippyDataUpdateCoordinator], 
 
     async def async_set_native_value(self, value: float) -> None:
         kippy_id = self._pet_data.get("kippyID") or self._pet_data.get("kippy_id")
+        gps_val = self._pet_data.get("gpsOnDefault")
+        if gps_val is None:
+            gps_val = self._pet_data.get("gps_on_default")
+        try:
+            gps_on_default = bool(int(gps_val))
+        except (TypeError, ValueError):
+            gps_on_default = bool(gps_val)
+
         if kippy_id is not None:
             data = await self.coordinator.api.modify_kippy_settings(
-                int(kippy_id), update_frequency=value
+                int(kippy_id), update_frequency=value, gps_on_default=gps_on_default
             )
             new_value = data.get("update_frequency", value)
             self._pet_data["updateFrequency"] = int(new_value)

--- a/custom_components/kippy/strings.json
+++ b/custom_components/kippy/strings.json
@@ -69,6 +69,13 @@
           "on": "On",
           "off": "Off"
         }
+      },
+      "gps_on_default": {
+        "name": "GPS tracking",
+        "state": {
+          "on": "On",
+          "off": "Off"
+        }
       }
     },
     "button": {

--- a/custom_components/kippy/translations/en.json
+++ b/custom_components/kippy/translations/en.json
@@ -71,6 +71,13 @@
           "on": "On",
           "off": "Off"
         }
+      },
+      "gps_on_default": {
+        "name": "GPS tracking",
+        "state": {
+          "on": "On",
+          "off": "Off"
+        }
       }
     },
     "button": {

--- a/tests/test_api_unit.py
+++ b/tests/test_api_unit.py
@@ -170,8 +170,8 @@ async def test_modify_kippy_settings_propagates_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_modify_kippy_settings_lowercase_bools(monkeypatch) -> None:
-    """gps_on_default is sent as lowercase booleans."""
+async def test_modify_kippy_settings_uses_bools(monkeypatch) -> None:
+    """gps_on_default is sent as boolean values."""
 
     api = KippyApi(MagicMock())
     api._auth = {"app_code": "1", "app_verification_code": "2"}
@@ -188,5 +188,5 @@ async def test_modify_kippy_settings_lowercase_bools(monkeypatch) -> None:
     await api.modify_kippy_settings(1, gps_on_default=True)
     await api.modify_kippy_settings(1, gps_on_default=False)
 
-    assert payloads[0]["gps_on_default"] == "true"
-    assert payloads[1]["gps_on_default"] == "false"
+    assert payloads[0]["gps_on_default"] is True
+    assert payloads[1]["gps_on_default"] is False


### PR DESCRIPTION
## Summary
- support `/v2/kippymap_modifyKippySettings.php` endpoint in API
- update energy saving and update frequency controls to call new endpoint
- add switch and translations for default GPS tracking toggle
- add negative and edge-case tests for settings updates

## Testing
- `python script/hassfest --integration-path custom_components/kippy`
- `pytest ./tests --cov=custom_components.kippy --cov-report term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68bcaf7b3a5c83268b4af1598a92fcd6