### PR TITLE
Tie live tracking switch to operating status

### DIFF
--- a/custom_components/kippy/switch.py
+++ b/custom_components/kippy/switch.py
@@ -208,6 +208,7 @@ class KippyLiveTrackingSwitch(
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         if self._read_only:
+            self.async_write_ha_state()
             raise HomeAssistantError(
                 "Live tracking cannot be enabled in energy saving mode"
             )
@@ -215,10 +216,19 @@ class KippyLiveTrackingSwitch(
             self.coordinator.kippy_id, app_action=1
         )
         self.coordinator.process_new_data(data)
+        if (
+            self.coordinator.data.get("operating_status")
+            == OPERATING_STATUS_MAP[OPERATING_STATUS.IDLE]
+        ):
+            self.coordinator.data["operating_status"] = OPERATING_STATUS_MAP[
+                OPERATING_STATUS.LIVE
+            ]
+        self._read_only = False
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         if self._read_only:
+            self.async_write_ha_state()
             raise HomeAssistantError(
                 "Live tracking cannot be disabled in energy saving mode"
             )
@@ -226,6 +236,14 @@ class KippyLiveTrackingSwitch(
             self.coordinator.kippy_id, app_action=1
         )
         self.coordinator.process_new_data(data)
+        if (
+            self.coordinator.data.get("operating_status")
+            == OPERATING_STATUS_MAP[OPERATING_STATUS.LIVE]
+        ):
+            self.coordinator.data["operating_status"] = OPERATING_STATUS_MAP[
+                OPERATING_STATUS.IDLE
+            ]
+        self._read_only = False
         self.async_write_ha_state()
 
     @property

--- a/custom_components/kippy/switch.py
+++ b/custom_components/kippy/switch.py
@@ -186,6 +186,10 @@ class KippyLiveTrackingSwitch(
         self._pet_name = pet_name
         self._pet_data = pet
         self._attr_translation_key = "toggle_live_tracking"
+        self._attr_available = (
+            coordinator.data.get("operating_status")
+            != OPERATING_STATUS_MAP[OPERATING_STATUS.ENERGY_SAVING]
+        )
 
     @property
     def is_on(self) -> bool:
@@ -193,6 +197,13 @@ class KippyLiveTrackingSwitch(
             self.coordinator.data.get("operating_status")
             == OPERATING_STATUS_MAP[OPERATING_STATUS.LIVE]
         )
+
+    def _handle_coordinator_update(self) -> None:
+        self._attr_available = (
+            self.coordinator.data.get("operating_status")
+            != OPERATING_STATUS_MAP[OPERATING_STATUS.ENERGY_SAVING]
+        )
+        super()._handle_coordinator_update()
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         data = await self.coordinator.api.kippymap_action(

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -41,7 +41,7 @@ async def test_energy_saving_switch_updates_from_operating_status() -> None:
 
 
 def test_live_tracking_switch_operating_status() -> None:
-    """Live tracking switch follows operating status and read-only state."""
+    """Live tracking switch follows operating status and availability."""
     pet = {"petID": 1}
     coordinator = MagicMock()
     coordinator.data = {
@@ -55,24 +55,24 @@ def test_live_tracking_switch_operating_status() -> None:
     switch.async_write_ha_state = MagicMock()
 
     assert switch.is_on
-    assert not switch._read_only
+    assert switch.available
 
     coordinator.data["operating_status"] = OPERATING_STATUS_MAP[OPERATING_STATUS.IDLE]
     switch._handle_coordinator_update()
     assert not switch.is_on
-    assert not switch._read_only
+    assert switch.available
 
     coordinator.data["operating_status"] = OPERATING_STATUS_MAP[
         OPERATING_STATUS.ENERGY_SAVING
     ]
     switch._handle_coordinator_update()
     assert not switch.is_on
-    assert switch._read_only
+    assert not switch.available
 
 
 @pytest.mark.asyncio
-async def test_live_tracking_switch_read_only_energy_saving() -> None:
-    """Live tracking switch blocks toggling in energy saving mode."""
+async def test_live_tracking_switch_unavailable_energy_saving() -> None:
+    """Live tracking switch is unavailable and blocks toggling in energy saving mode."""
     pet = {"petID": 1}
     coordinator = MagicMock()
     coordinator.data = {
@@ -87,7 +87,7 @@ async def test_live_tracking_switch_read_only_energy_saving() -> None:
     switch.async_write_ha_state = MagicMock()
 
     assert not switch.is_on
-    assert switch._read_only
+    assert not switch.available
 
     with pytest.raises(HomeAssistantError):
         await switch.async_turn_on()


### PR DESCRIPTION
## Summary
- tie live tracking switch availability to device operating status
- add tests for live tracking switch state and availability

## Testing
- `python script/hassfest --integration-path custom_components/kippy`
- `pytest ./tests --cov=custom_components.kippy --cov-report term-missing`

------
https://chatgpt.com/codex/tasks/task_e_68bcc41024088326877f0ee720b0f075