### PR TITLE
Add next call time sensor

### DIFF
--- a/custom_components/kippy/strings.json
+++ b/custom_components/kippy/strings.json
@@ -53,6 +53,9 @@
           "dog": "Dog",
           "cat": "Cat"
         }
+      },
+      "next_call_time": {
+        "name": "Next call time"
       }
     },
     "switch": {

--- a/custom_components/kippy/translations/en.json
+++ b/custom_components/kippy/translations/en.json
@@ -55,6 +55,9 @@
           "dog": "Dog",
           "cat": "Cat"
         }
+      },
+      "next_call_time": {
+        "name": "Next call time"
       }
     },
     "switch": {


### PR DESCRIPTION
## Summary
- add `KippyNextCallTimeSensor` to show next scheduled contact time
- translate `next_call_time` sensor strings
- test coverage for next call time sensor

## Testing
- `python script/hassfest --integration-path custom_components/kippy`
- `pytest tests/test_sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd573b5b9c83269d3a8c7c12283d60