### PR TITLE
Fix energy saving notification

### DIFF
--- a/custom_components/kippy/switch.py
+++ b/custom_components/kippy/switch.py
@@ -138,7 +138,7 @@ class KippyEnergySavingSwitch(
             )
         self._pet_data["energySavingMode"] = 1
         self.async_write_ha_state()
-        self._notify_next_call_time()
+        await self._notify_next_call_time()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         kippy_id = self._pet_data.get("kippyID") or self._pet_data.get("kippy_id")
@@ -148,10 +148,11 @@ class KippyEnergySavingSwitch(
             )
         self._pet_data["energySavingMode"] = 0
         self.async_write_ha_state()
-        self._notify_next_call_time()
+        await self._notify_next_call_time()
 
-    def _notify_next_call_time(self) -> None:
+    async def _notify_next_call_time(self) -> None:
         """Notify user that change will apply at next call time."""
+        await self._map_coordinator.async_request_refresh()
         if not self._map_coordinator.data:
             return
         ts = self._map_coordinator.data.get("next_call_time")

--- a/custom_components/kippy/switch.py
+++ b/custom_components/kippy/switch.py
@@ -138,7 +138,7 @@ class KippyEnergySavingSwitch(
             )
         self._pet_data["energySavingMode"] = 1
         self.async_write_ha_state()
-        await self._notify_next_call_time()
+        self._notify_next_call_time()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         kippy_id = self._pet_data.get("kippyID") or self._pet_data.get("kippy_id")
@@ -148,8 +148,9 @@ class KippyEnergySavingSwitch(
             )
         self._pet_data["energySavingMode"] = 0
         self.async_write_ha_state()
-        await self._notify_next_call_time()
-    async def _notify_next_call_time(self) -> None:
+        self._notify_next_call_time()
+
+    def _notify_next_call_time(self) -> None:
         """Notify user that change will apply at next call time."""
         if not self._map_coordinator.data:
             return
@@ -165,7 +166,7 @@ class KippyEnergySavingSwitch(
             f"This change will apply in {hours} hours at "
             f"{local_time.isoformat()}"
         )
-        await persistent_notification.async_create(
+        persistent_notification.async_create(
             self.hass, message, title=self.name
         )
 

--- a/custom_components/kippy/switch.py
+++ b/custom_components/kippy/switch.py
@@ -138,7 +138,7 @@ class KippyEnergySavingSwitch(
             )
         self._pet_data["energySavingMode"] = 1
         self.async_write_ha_state()
-        self._notify_next_call_time()
+        await self._notify_next_call_time()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         kippy_id = self._pet_data.get("kippyID") or self._pet_data.get("kippy_id")
@@ -148,8 +148,8 @@ class KippyEnergySavingSwitch(
             )
         self._pet_data["energySavingMode"] = 0
         self.async_write_ha_state()
-        self._notify_next_call_time()
-    def _notify_next_call_time(self) -> None:
+        await self._notify_next_call_time()
+    async def _notify_next_call_time(self) -> None:
         """Notify user that change will apply at next call time."""
         if not self._map_coordinator.data:
             return
@@ -165,7 +165,7 @@ class KippyEnergySavingSwitch(
             f"This change will apply in {hours} hours at "
             f"{local_time.isoformat()}"
         )
-        persistent_notification.async_create(
+        await persistent_notification.async_create(
             self.hass, message, title=self.name
         )
 

--- a/custom_components/kippy/switch.py
+++ b/custom_components/kippy/switch.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
-from homeassistant.components import persistent_notification
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -167,8 +166,10 @@ class KippyEnergySavingSwitch(
             f"This change will apply in {hours} hours at "
             f"{local_time.isoformat()}"
         )
-        persistent_notification.async_create(
-            self.hass, message, title=self.name
+        await self.hass.services.async_call(
+            "persistent_notification",
+            "create",
+            {"message": message, "title": self.name},
         )
 
     def _handle_coordinator_update(self) -> None:

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -123,14 +123,13 @@ async def test_energy_saving_switch_calls_api() -> None:
     with (
         patch(
             "homeassistant.components.persistent_notification.async_create",
-            AsyncMock(),
         ) as notify,
         patch("homeassistant.util.dt.utcnow", return_value=now),
     ):
         await switch.async_turn_on()
         await switch.async_turn_off()
-        assert notify.await_count == 2
-        message = notify.await_args[0][1]
+        assert notify.call_count == 2
+        message = notify.call_args_list[0][0][1]
         assert "1 hours" in message
     coordinator.api.modify_kippy_settings.assert_has_awaits(
         [
@@ -292,7 +291,6 @@ async def test_energy_saving_switch_no_kippy_id() -> None:
     with (
         patch(
             "homeassistant.components.persistent_notification.async_create",
-            AsyncMock(),
         ),
         patch("homeassistant.util.dt.utcnow", return_value=now),
     ):

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -121,13 +121,16 @@ async def test_energy_saving_switch_calls_api() -> None:
     switch.hass = MagicMock()
     switch.async_write_ha_state = MagicMock()
     with (
-        patch("homeassistant.components.persistent_notification.async_create", MagicMock()) as notify,
+        patch(
+            "homeassistant.components.persistent_notification.async_create",
+            AsyncMock(),
+        ) as notify,
         patch("homeassistant.util.dt.utcnow", return_value=now),
     ):
         await switch.async_turn_on()
         await switch.async_turn_off()
-        assert notify.call_count == 2
-        message = notify.call_args[0][1]
+        assert notify.await_count == 2
+        message = notify.await_args[0][1]
         assert "1 hours" in message
     coordinator.api.modify_kippy_settings.assert_has_awaits(
         [
@@ -287,7 +290,10 @@ async def test_energy_saving_switch_no_kippy_id() -> None:
     switch.hass = MagicMock()
     switch.async_write_ha_state = MagicMock()
     with (
-        patch("homeassistant.components.persistent_notification.async_create", MagicMock()),
+        patch(
+            "homeassistant.components.persistent_notification.async_create",
+            AsyncMock(),
+        ),
         patch("homeassistant.util.dt.utcnow", return_value=now),
     ):
         await switch.async_turn_on()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -114,6 +114,7 @@ async def test_energy_saving_switch_calls_api() -> None:
     coordinator.api.modify_kippy_settings = AsyncMock()
     map_coordinator = MagicMock()
     map_coordinator.async_add_listener = MagicMock(return_value=MagicMock())
+    map_coordinator.async_request_refresh = AsyncMock()
     now = datetime(2024, 1, 1, tzinfo=timezone.utc)
     next_call = now + timedelta(hours=1)
     map_coordinator.data = {"next_call_time": int(next_call.timestamp())}
@@ -137,6 +138,7 @@ async def test_energy_saving_switch_calls_api() -> None:
             call(1, energy_saving_mode=False),
         ]
     )
+    assert map_coordinator.async_request_refresh.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -282,6 +284,7 @@ async def test_energy_saving_switch_no_kippy_id() -> None:
     coordinator.api.modify_kippy_settings = AsyncMock()
     map_coordinator = MagicMock()
     map_coordinator.async_add_listener = MagicMock(return_value=MagicMock())
+    map_coordinator.async_request_refresh = AsyncMock()
     now = datetime(2024, 1, 1, tzinfo=timezone.utc)
     next_call = now + timedelta(hours=1)
     map_coordinator.data = {"next_call_time": int(next_call.timestamp())}
@@ -404,6 +407,7 @@ def test_energy_saving_switch_turn_on_off_and_device_info() -> None:
     coordinator.api.modify_kippy_settings = AsyncMock()
     map_coord = MagicMock()
     map_coord.async_add_listener = MagicMock(return_value=MagicMock())
+    map_coord.async_request_refresh = AsyncMock()
     map_coord.data = {}
     switch = KippyEnergySavingSwitch(coordinator, pet, map_coord)
     switch.async_write_ha_state = MagicMock()


### PR DESCRIPTION
## Summary
- ensure energy saving switch awaits persistent notification
- adjust tests for async notification

## Testing
- `pre-commit run --files custom_components/kippy/switch.py tests/test_switch.py` *(fails: CalledProcessError: command: ('/root/.pyenv/versions/3.13.3/bin/python', '-mnodeenv', '--prebuilt', '--clean-src', '/root/.cache/pre-commit/repo5g3jubew/node_env-default') stderr: ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed)*
- `python script/hassfest --integration-path custom_components/kippy`
- `pytest ./tests --cov=custom_components.kippy --cov-report term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68bd75e6321483268dc8d0bec1d0a3c7