### PR TITLE
Fix live tracking start command

### DIFF
--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -421,7 +421,6 @@ class KippyApi:
         do_sms: bool = True,
         app_action: int | None = None,
         geofence_id: int | None = None,
-        map_action: int | None = None,
     ) -> Dict[str, Any]:
         """Perform a kippymap action for a specific device."""
 
@@ -441,8 +440,6 @@ class KippyApi:
             payload["app_action"] = app_action
         if geofence_id is not None:
             payload["geofence_id"] = geofence_id
-        if map_action is not None:
-            payload["map_action"] = map_action
 
         data = await self._post_with_refresh(
             KIPPYMAP_ACTION_PATH, payload, REQUEST_HEADERS

--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -1,4 +1,5 @@
 """Simple API client for Kippy."""
+
 from __future__ import annotations
 
 import asyncio
@@ -116,7 +117,9 @@ def _treat_401_as_success(path: str, data: Dict[str, Any]) -> bool:
     """Determine if a 401 response should be treated as a success."""
     return_code = _get_return_code(data)
     if return_code is None:
-        _LOGGER.debug("%s returned HTTP 401 without return code, treating as failure", path)
+        _LOGGER.debug(
+            "%s returned HTTP 401 without return code, treating as failure", path
+        )
         return False
     if isinstance(return_code, bool):
         if return_code:
@@ -315,9 +318,7 @@ class KippyApi:
         for attempt in range(2):
             try:
                 if _LOGGER.isEnabledFor(logging.DEBUG):
-                    _LOGGER.debug(
-                        "%s request: %s", path, json.dumps(_redact(payload))
-                    )
+                    _LOGGER.debug("%s request: %s", path, json.dumps(_redact(payload)))
                 async with self._session.post(
                     self._url(path),
                     data=json.dumps(payload),
@@ -420,6 +421,7 @@ class KippyApi:
         do_sms: bool = True,
         app_action: int | None = None,
         geofence_id: int | None = None,
+        map_action: int | None = None,
     ) -> Dict[str, Any]:
         """Perform a kippymap action for a specific device."""
 
@@ -439,6 +441,8 @@ class KippyApi:
             payload["app_action"] = app_action
         if geofence_id is not None:
             payload["geofence_id"] = geofence_id
+        if map_action is not None:
+            payload["map_action"] = map_action
 
         data = await self._post_with_refresh(
             KIPPYMAP_ACTION_PATH, payload, REQUEST_HEADERS

--- a/custom_components/kippy/const.py
+++ b/custom_components/kippy/const.py
@@ -1,4 +1,5 @@
 """Constants for the Kippy integration."""
+
 import json
 from importlib import resources
 from types import SimpleNamespace
@@ -110,6 +111,12 @@ OPERATING_STATUS_MAP: dict[int, str] = {
     OPERATING_STATUS.LIVE: "live",
     OPERATING_STATUS.ENERGY_SAVING: "energy_saving",
 }
+
+# Map action identifiers used by the API.
+MAP_ACTION = SimpleNamespace(
+    TURN_LIVE_TRACKING_ON=2,
+    TURN_LIVE_TRACKING_OFF=1,
+)
 
 # Names used by the API for location technologies.
 LOCALIZATION_TECHNOLOGY_LBS = "LBS (Low accuracy)"

--- a/custom_components/kippy/const.py
+++ b/custom_components/kippy/const.py
@@ -112,8 +112,8 @@ OPERATING_STATUS_MAP: dict[int, str] = {
     OPERATING_STATUS.ENERGY_SAVING: "energy_saving",
 }
 
-# Map action identifiers used by the API.
-MAP_ACTION = SimpleNamespace(
+# App action identifiers used by the API.
+APP_ACTION = SimpleNamespace(
     TURN_LIVE_TRACKING_ON=2,
     TURN_LIVE_TRACKING_OFF=1,
 )

--- a/custom_components/kippy/strings.json
+++ b/custom_components/kippy/strings.json
@@ -59,8 +59,8 @@
       }
     },
     "switch": {
-      "toggle_live_tracking": {
-        "name": "Toggle live tracking",
+      "live_tracking": {
+        "name": "Live tracking",
         "state": {
           "on": "On",
           "off": "Off"

--- a/custom_components/kippy/switch.py
+++ b/custom_components/kippy/switch.py
@@ -13,9 +13,9 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
+    APP_ACTION,
     DOMAIN,
     LOCALIZATION_TECHNOLOGY_LBS,
-    MAP_ACTION,
     OPERATING_STATUS,
     OPERATING_STATUS_MAP,
 )
@@ -212,7 +212,7 @@ class KippyLiveTrackingSwitch(
             )
         data = await self.coordinator.api.kippymap_action(
             self.coordinator.kippy_id,
-            app_action=MAP_ACTION.TURN_LIVE_TRACKING_ON,
+            app_action=APP_ACTION.TURN_LIVE_TRACKING_ON,
         )
         self.coordinator.process_new_data(data)
         if (
@@ -232,7 +232,7 @@ class KippyLiveTrackingSwitch(
             )
         data = await self.coordinator.api.kippymap_action(
             self.coordinator.kippy_id,
-            map_action=MAP_ACTION.TURN_LIVE_TRACKING_OFF,
+            app_action=APP_ACTION.TURN_LIVE_TRACKING_OFF,
         )
         self.coordinator.process_new_data(data)
         if (

--- a/custom_components/kippy/switch.py
+++ b/custom_components/kippy/switch.py
@@ -173,7 +173,7 @@ class KippyEnergySavingSwitch(
 class KippyLiveTrackingSwitch(
     CoordinatorEntity[KippyMapDataUpdateCoordinator], SwitchEntity
 ):
-    """Switch to toggle live tracking."""
+    """Switch for live tracking."""
 
     def __init__(
         self, coordinator: KippyMapDataUpdateCoordinator, pet: dict[str, Any]
@@ -181,13 +181,11 @@ class KippyLiveTrackingSwitch(
         super().__init__(coordinator)
         self._pet_id = pet["petID"]
         pet_name = pet.get("petName")
-        self._attr_name = (
-            f"{pet_name} Toggle live tracking" if pet_name else "Toggle live tracking"
-        )
-        self._attr_unique_id = f"{self._pet_id}_toggle_live_tracking"
+        self._attr_name = f"{pet_name} Live tracking" if pet_name else "Live tracking"
+        self._attr_unique_id = f"{self._pet_id}_live_tracking"
         self._pet_name = pet_name
         self._pet_data = pet
-        self._attr_translation_key = "toggle_live_tracking"
+        self._attr_translation_key = "live_tracking"
 
     @property
     def is_on(self) -> bool:

--- a/custom_components/kippy/translations/en.json
+++ b/custom_components/kippy/translations/en.json
@@ -61,8 +61,8 @@
       }
     },
     "switch": {
-      "toggle_live_tracking": {
-        "name": "Toggle live tracking",
+      "live_tracking": {
+        "name": "Live tracking",
         "state": {
           "on": "On",
           "off": "Off"

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -5,8 +5,8 @@ import pytest
 from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.kippy.const import (
+    APP_ACTION,
     DOMAIN,
-    MAP_ACTION,
     OPERATING_STATUS,
     OPERATING_STATUS_MAP,
 )
@@ -146,7 +146,7 @@ async def test_live_tracking_switch_turns_on_off() -> None:
     switch.async_write_ha_state = MagicMock()
     await switch.async_turn_on()
     coordinator.api.kippymap_action.assert_called_once_with(
-        1, app_action=MAP_ACTION.TURN_LIVE_TRACKING_ON
+        1, app_action=APP_ACTION.TURN_LIVE_TRACKING_ON
     )
     coordinator.process_new_data.assert_called_once()
     assert (
@@ -161,7 +161,7 @@ async def test_live_tracking_switch_turns_on_off() -> None:
     coordinator.data["operating_status"] = OPERATING_STATUS_MAP[OPERATING_STATUS.LIVE]
     await switch.async_turn_off()
     coordinator.api.kippymap_action.assert_called_once_with(
-        1, map_action=MAP_ACTION.TURN_LIVE_TRACKING_OFF
+        1, app_action=APP_ACTION.TURN_LIVE_TRACKING_OFF
     )
     coordinator.process_new_data.assert_called_once()
     assert (

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2,16 +2,21 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
+from homeassistant.exceptions import HomeAssistantError
 
-from custom_components.kippy.const import DOMAIN, OPERATING_STATUS, OPERATING_STATUS_MAP
+from custom_components.kippy.const import (
+    DOMAIN,
+    MAP_ACTION,
+    OPERATING_STATUS,
+    OPERATING_STATUS_MAP,
+)
 from custom_components.kippy.switch import (
     KippyEnergySavingSwitch,
+    KippyGpsDefaultSwitch,
     KippyIgnoreLBSSwitch,
     KippyLiveTrackingSwitch,
-    KippyGpsDefaultSwitch,
     async_setup_entry,
 )
-from homeassistant.exceptions import HomeAssistantError
 
 
 @pytest.mark.asyncio
@@ -44,9 +49,7 @@ def test_live_tracking_switch_operating_status() -> None:
     """Live tracking switch follows operating status and availability."""
     pet = {"petID": 1}
     coordinator = MagicMock()
-    coordinator.data = {
-        "operating_status": OPERATING_STATUS_MAP[OPERATING_STATUS.LIVE]
-    }
+    coordinator.data = {"operating_status": OPERATING_STATUS_MAP[OPERATING_STATUS.LIVE]}
     coordinator.async_add_listener = MagicMock()
     coordinator.last_update_success = True
     switch = KippyLiveTrackingSwitch(coordinator, pet)
@@ -130,9 +133,7 @@ async def test_live_tracking_switch_turns_on_off() -> None:
     """Live tracking switch calls API and processes data."""
     pet = {"petID": 1, "petName": "Rex"}
     coordinator = MagicMock()
-    coordinator.data = {
-        "operating_status": OPERATING_STATUS_MAP[OPERATING_STATUS.IDLE]
-    }
+    coordinator.data = {"operating_status": OPERATING_STATUS_MAP[OPERATING_STATUS.IDLE]}
     coordinator.kippy_id = 1
     coordinator.api.kippymap_action = AsyncMock(
         return_value={"operating_status": OPERATING_STATUS_MAP[OPERATING_STATUS.LIVE]}
@@ -144,8 +145,10 @@ async def test_live_tracking_switch_turns_on_off() -> None:
     switch.entity_id = "switch.live"
     switch.async_write_ha_state = MagicMock()
     await switch.async_turn_on()
-    coordinator.api.kippymap_action.assert_called()
-    coordinator.process_new_data.assert_called()
+    coordinator.api.kippymap_action.assert_called_once_with(
+        1, app_action=MAP_ACTION.TURN_LIVE_TRACKING_ON
+    )
+    coordinator.process_new_data.assert_called_once()
     assert (
         coordinator.data.get("operating_status")
         == OPERATING_STATUS_MAP[OPERATING_STATUS.LIVE]
@@ -157,8 +160,10 @@ async def test_live_tracking_switch_turns_on_off() -> None:
     }
     coordinator.data["operating_status"] = OPERATING_STATUS_MAP[OPERATING_STATUS.LIVE]
     await switch.async_turn_off()
-    coordinator.api.kippymap_action.assert_called()
-    coordinator.process_new_data.assert_called()
+    coordinator.api.kippymap_action.assert_called_once_with(
+        1, map_action=MAP_ACTION.TURN_LIVE_TRACKING_OFF
+    )
+    coordinator.process_new_data.assert_called_once()
     assert (
         coordinator.data.get("operating_status")
         == OPERATING_STATUS_MAP[OPERATING_STATUS.IDLE]
@@ -361,7 +366,9 @@ async def test_switch_async_setup_entry_missing_map() -> None:
     base_coordinator = MagicMock()
     base_coordinator.data = {"pets": [{"petID": 1}]}
     hass.data = {
-        DOMAIN: {entry.entry_id: {"coordinator": base_coordinator, "map_coordinators": {}}}
+        DOMAIN: {
+            entry.entry_id: {"coordinator": base_coordinator, "map_coordinators": {}}
+        }
     }
     async_add_entities = MagicMock()
     await async_setup_entry(hass, entry, async_add_entities)


### PR DESCRIPTION
## Summary
- send `app_action: 2` to start live tracking
- use `map_action: 1` to stop live tracking
- store map action identifiers in constants
- test live tracking parameters

## Testing
- `SKIP=prettier pre-commit run --files custom_components/kippy/const.py custom_components/kippy/switch.py tests/test_switch.py`
- `python script/hassfest --integration-path custom_components/kippy`
- `pytest ./tests --cov=custom_components.kippy --cov-report term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68bd8906e72c8326a6a50d40fca31823