### PR TITLE
Ensure consistent notification when toggling energy saving mode

### DIFF
--- a/custom_components/kippy/switch.py
+++ b/custom_components/kippy/switch.py
@@ -13,10 +13,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import dt as dt_util
-
-from .helpers import build_device_info
 
 from .const import (
     APP_ACTION,
@@ -142,7 +139,7 @@ class KippyEnergySavingSwitch(
             )
         self._pet_data["energySavingMode"] = 1
         self.async_write_ha_state()
-        await self._notify_next_call_time()
+        await self._async_notify_next_call_time()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         kippy_id = self._pet_data.get("kippyID") or self._pet_data.get("kippy_id")
@@ -152,9 +149,9 @@ class KippyEnergySavingSwitch(
             )
         self._pet_data["energySavingMode"] = 0
         self.async_write_ha_state()
-        self._notify_next_call_time()
+        await self._async_notify_next_call_time()
 
-    def _notify_next_call_time(self) -> None:
+    async def _async_notify_next_call_time(self) -> None:
         """Notify user that change will apply at next call time."""
         await self._map_coordinator.async_request_refresh()
         if not self._map_coordinator.data:

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -130,8 +130,10 @@ async def test_energy_saving_switch_calls_api() -> None:
         await switch.async_turn_on()
         await switch.async_turn_off()
     assert switch.hass.services.async_call.await_count == 2
-    message = switch.hass.services.async_call.await_args_list[0].args[2]["message"]
-    assert "1 hours" in message
+    message_on = switch.hass.services.async_call.await_args_list[0].args[2]["message"]
+    message_off = switch.hass.services.async_call.await_args_list[1].args[2]["message"]
+    assert "1 hours" in message_on
+    assert "1 hours" in message_off
     coordinator.api.modify_kippy_settings.assert_has_awaits(
         [
             call(1, energy_saving_mode=True),


### PR DESCRIPTION
## Summary
- use async helper `_async_notify_next_call_time` for energy-saving switch
- test both enable/disable paths trigger notifications

## Testing
- `pre-commit run --files custom_components/kippy/switch.py tests/test_switch.py`
- `python script/hassfest --integration-path custom_components/kippy`
- `pytest tests/test_switch.py`
- `pytest ./tests --cov=custom_components.kippy --cov-report term-missing` *(fails: SocketBlockedError in tests/test_api)*

------
https://chatgpt.com/codex/tasks/task_e_68be06faf0348326a9806f5d30d11844