### PR TITLE
Notify delay when toggling Kippy energy saving mode

### DIFF
--- a/custom_components/kippy/switch.py
+++ b/custom_components/kippy/switch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.persistent_notification import DOMAIN as PN_DOMAIN
+from homeassistant.components.frontend import DOMAIN as FRONTEND_DOMAIN
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
@@ -177,8 +177,8 @@ class KippyEnergySavingSwitch(
             return
 
         await self.hass.services.async_call(
-            PN_DOMAIN,
-            "create",
+            FRONTEND_DOMAIN,
+            "show-toast",
             {"title": self.name, "message": f"Update will apply in {time_text}."},
             blocking=False,
         )


### PR DESCRIPTION
## Summary
- Inform users that energy-saving changes take effect after the next scheduled contact using the integration's next call time sensor
- Test energy-saving switch notification logic using Home Assistant's persistent notification component
- Derive next-call time in tests from the sensor instead of hard-coding a one-hour offset

## Testing
- `pre-commit run --files custom_components/kippy/switch.py tests/test_switch.py`
- `python script/hassfest --integration-path custom_components/kippy`
- `KIPPY_EMAIL="<REDACTED>" KIPPY_PASSWORD="<REDACTED>" pytest ./tests --cov=custom_components.kippy --cov-report term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68be0af39e6c8326b1e63339a6e9678f