### PR TITLE
Install turbojpeg for codex hassfest tests

### DIFF
--- a/script/codex.sh
+++ b/script/codex.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Ensure system trust store is present for network operations
 apt-get update
-apt-get install -y ca-certificates
+apt-get install -y ca-certificates libturbojpeg
 update-ca-certificates
 
 PY_VERSION="3.13.3"


### PR DESCRIPTION
## Summary
- Install `libturbojpeg` in `codex.sh` so PyTurboJPEG can load its native library

## Testing
- `python script/hassfest --integration-path custom_components/kippy`
- `pytest ./tests --cov=custom_components.kippy --cov-report term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68bfd4921bf88326b317de9aedd2b595