### PR TITLE
Use Home Assistant timezone for activity data

### DIFF
--- a/custom_components/kippy/api.py
+++ b/custom_components/kippy/api.py
@@ -8,6 +8,7 @@ import json
 import logging
 import ssl
 from datetime import datetime, timedelta
+from homeassistant.util import dt as dt_util
 from typing import Any, Dict, Optional, cast
 
 from aiohttp import ClientError, ClientResponseError, ClientSession
@@ -528,12 +529,10 @@ class KippyApi:
         start = datetime.strptime(from_date, "%Y-%m-%d")
         end = datetime.strptime(to_date, "%Y-%m-%d")
 
-        start_ts = int(
-            start.replace(tzinfo=datetime.now().astimezone().tzinfo).timestamp()
-        )
-        end_ts = int(end.replace(tzinfo=datetime.now().astimezone().tzinfo).timestamp())
+        start_ts = int(start.replace(tzinfo=dt_util.now().tzinfo).timestamp())
+        end_ts = int(end.replace(tzinfo=dt_util.now().tzinfo).timestamp())
 
-        tz_hours = _tz_hours(start.replace(tzinfo=datetime.now().astimezone().tzinfo))
+        tz_hours = _tz_hours(start.replace(tzinfo=dt_util.now().tzinfo))
 
         weeks_param = _weeks_param(start, end)
 

--- a/custom_components/kippy/coordinator.py
+++ b/custom_components/kippy/coordinator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import inspect
 import logging
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -17,6 +17,7 @@ from .const import (
     OPERATING_STATUS,
     OPERATING_STATUS_MAP,
 )
+from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -176,7 +177,7 @@ class KippyActivityCategoriesDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self) -> dict[int, dict[str, Any]]:
         """Fetch activity categories for all configured pets."""
-        now = datetime.now().astimezone()
+        now = dt_util.now()
         from_date = now.strftime("%Y-%m-%d")
         to_date = (now + timedelta(days=1)).strftime("%Y-%m-%d")
         data: dict[int, dict[str, Any]] = {}
@@ -191,7 +192,7 @@ class KippyActivityCategoriesDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def async_refresh_pet(self, pet_id: int) -> None:
         """Manually refresh activity data for a single pet."""
-        now = datetime.now().astimezone()
+        now = dt_util.now()
         from_date = now.strftime("%Y-%m-%d")
         to_date = (now + timedelta(days=1)).strftime("%Y-%m-%d")
         result = await self.api.get_activity_categories(

--- a/custom_components/kippy/sensor.py
+++ b/custom_components/kippy/sensor.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.location import distance as location_distance
 from homeassistant.util.unit_conversion import DistanceConverter, DurationConverter
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, LABEL_EXPIRED, LOCALIZATION_TECHNOLOGY_GPS, PET_KIND_TO_TYPE
 from .coordinator import (
@@ -266,7 +267,7 @@ class _KippyActivitySensor(
         activities = self.coordinator.get_activities(self._pet_id)
         if not activities:
             return None
-        today = datetime.now().astimezone()
+        today = dt_util.now()
         value: Any = None
 
         # Cat trackers return data grouped by activity rather than by day.

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -155,12 +155,7 @@ async def test_activity_coordinator_update_and_refresh() -> None:
     )
     fake_now = datetime(2020, 1, 2, 12, 0, tzinfo=timezone.utc)
 
-    class FakeDatetime(datetime):
-        @classmethod
-        def now(cls, tz=None):
-            return fake_now if tz is None else fake_now.astimezone(tz)
-
-    with patch("custom_components.kippy.coordinator.datetime", FakeDatetime):
+    with patch("homeassistant.util.dt.now", return_value=fake_now):
         coord = KippyActivityCategoriesDataUpdateCoordinator(
             hass, MagicMock(), api, [1]
         )


### PR DESCRIPTION
## Summary
- use Home Assistant timezone utilities for activity coordinator and activity sensors
- calculate API activity timestamps using Home Assistant timezone
- update tests for new timezone helper usage

## Testing
- `python script/hassfest --integration-path custom_components/kippy`
- `KIPPY_EMAIL='<REDACTED>' KIPPY_PASSWORD='<REDACTED>' pytest ./tests --cov=custom_components.kippy --cov-report term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68c0a2649750832687101b5e3b94a7a5