### PR TITLE
Disable GPS activation switch for expired subscriptions

### DIFF
--- a/custom_components/kippy/switch.py
+++ b/custom_components/kippy/switch.py
@@ -34,6 +34,14 @@ async def async_setup_entry(
     map_coordinators = hass.data[DOMAIN][entry.entry_id]["map_coordinators"]
     entities: list[SwitchEntity] = []
     for pet in coordinator.data.get("pets", []):
+        expired_days = pet.get("expired_days")
+        is_expired = False
+        try:
+            is_expired = int(expired_days) >= 0
+        except (TypeError, ValueError):
+            pass
+        if is_expired:
+            continue
         entities.append(KippyGpsDefaultSwitch(coordinator, pet))
         map_coord = map_coordinators.get(pet["petID"])
         if not map_coord:

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -388,6 +388,22 @@ async def test_switch_async_setup_entry_no_pets() -> None:
 
 
 @pytest.mark.asyncio
+async def test_switch_async_setup_entry_expired_pet() -> None:
+    """Expired pets should not create switch entities."""
+    hass = MagicMock()
+    entry = MagicMock()
+    entry.entry_id = "1"
+    base_coordinator = MagicMock()
+    base_coordinator.data = {"pets": [{"petID": 1, "expired_days": 0}]}
+    hass.data = {
+        DOMAIN: {entry.entry_id: {"coordinator": base_coordinator, "map_coordinators": {}}}
+    }
+    async_add_entities = MagicMock()
+    await async_setup_entry(hass, entry, async_add_entities)
+    async_add_entities.assert_called_once_with([])
+
+
+@pytest.mark.asyncio
 async def test_switch_async_setup_entry_missing_map() -> None:
     """No switches added when map coordinator is missing."""
     hass = MagicMock()


### PR DESCRIPTION
## Summary
- skip creating GPS activation switch when a pet's subscription is expired
- add regression test to ensure expired pets don't create switch entities

## Testing
- `python script/hassfest --integration-path custom_components/kippy`
- `pytest ./tests --cov=custom_components.kippy --cov-report term-missing`
- `pre-commit run --files custom_components/kippy/switch.py tests/test_switch.py` *(fails: certificate verify failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c45a366a088326b71b0a123b9ff5b1